### PR TITLE
유저 소셜 회원가입 및 로그인 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,20 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	runtimeOnly 'com.h2database:h2'
+
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/recipetory/config/WebConfiguration.java
+++ b/src/main/java/com/recipetory/config/WebConfiguration.java
@@ -1,0 +1,20 @@
+package com.recipetory.config;
+
+import com.recipetory.config.auth.argumentresolver.LogInUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+    private final LogInUserArgumentResolver logInUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers){
+        argumentResolvers.add(logInUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/recipetory/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/recipetory/config/auth/CustomOAuth2UserService.java
@@ -49,7 +49,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         return new DefaultOAuth2User(
                 Collections.singleton(loggedInUser.createAuthority()),
                 oAuthAttributes.getAttributes(),
-                userNameAttributeName);
+                oAuthAttributes.getUserNameAttributeName());
     }
 
     @Transactional

--- a/src/main/java/com/recipetory/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/recipetory/config/auth/CustomOAuth2UserService.java
@@ -1,0 +1,60 @@
+package com.recipetory.config.auth;
+
+import com.recipetory.config.auth.dto.OAuthAttributes;
+import com.recipetory.config.auth.dto.SessionUser;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.UserRepository;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+    private final HttpSession httpSession;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 1. resource server 정보 추출
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+
+        // 2. resource server 에서 provider specific attribute, key field 추출
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+        // 3. general attribute 추출
+        OAuthAttributes oAuthAttributes = OAuthAttributes
+                .of(provider, userNameAttributeName, oAuth2User.getAttributes());
+
+        // 4. attributes 토대로 회원가입 or 로그인 user 정보 가져오기
+        User loggedInUser = saveIfNew(oAuthAttributes);
+
+        // 5. session에 현재 로그인한 유저 정보 저장
+        httpSession.setAttribute("user", SessionUser.fromEntity(loggedInUser));
+
+        // 6. security context에 등록할 oauth2 user return
+        return new DefaultOAuth2User(
+                Collections.singleton(loggedInUser.createAuthority()),
+                oAuthAttributes.getAttributes(),
+                userNameAttributeName);
+    }
+
+    @Transactional
+    private User saveIfNew(OAuthAttributes oAuthAttributes) {
+        return userRepository.findByEmail(oAuthAttributes.getEmail())
+                .orElseGet(() -> userRepository.save(oAuthAttributes.toEntity()));
+    }
+}

--- a/src/main/java/com/recipetory/config/auth/SecurityConfiguration.java
+++ b/src/main/java/com/recipetory/config/auth/SecurityConfiguration.java
@@ -1,0 +1,47 @@
+package com.recipetory.config.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfiguration {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    // since spring security 6.1.2 : MvcRequestMatcher.Builder
+    // https://github.com/spring-projects/spring-security-samples/tree/main/servlet/java-configuration/authentication/preauth
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http, MvcRequestMatcher.Builder mvc) throws Exception {
+        http
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(mvc.pattern("/check")).authenticated()
+                        .anyRequest().permitAll())
+                // for h2-console
+                .headers(headers -> headers.frameOptions(option -> option.disable()))
+                .csrf(csrf -> csrf.disable())
+                .oauth2Login(oauth -> oauth
+                        .userInfoEndpoint(userInfo ->
+                                userInfo.userService(customOAuth2UserService)))
+                .logout(logout -> logout
+                        .logoutSuccessUrl("/")
+                        .invalidateHttpSession(true));
+
+        return http.build();
+    }
+
+    @Bean
+    MvcRequestMatcher.Builder mvc(HandlerMappingIntrospector introspector) {
+        return new MvcRequestMatcher.Builder(introspector);
+    }
+}

--- a/src/main/java/com/recipetory/config/auth/SecurityConfiguration.java
+++ b/src/main/java/com/recipetory/config/auth/SecurityConfiguration.java
@@ -5,11 +5,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 @Configuration

--- a/src/main/java/com/recipetory/config/auth/argumentresolver/LogInUser.java
+++ b/src/main/java/com/recipetory/config/auth/argumentresolver/LogInUser.java
@@ -1,0 +1,11 @@
+package com.recipetory.config.auth.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogInUser {
+}

--- a/src/main/java/com/recipetory/config/auth/argumentresolver/LogInUserArgumentResolver.java
+++ b/src/main/java/com/recipetory/config/auth/argumentresolver/LogInUserArgumentResolver.java
@@ -1,0 +1,43 @@
+package com.recipetory.config.auth.argumentresolver;
+
+import com.recipetory.config.auth.dto.SessionUser;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class LogInUserArgumentResolver implements HandlerMethodArgumentResolver {
+    private final HttpSession httpSession;
+
+    /**
+     * 두가지 조건을 검사하여 SessionUser를 method arg에 binding합니다.
+     * 1. handler method의 parameter에 @LogInUserrk 붙었는지
+     * 2. 해당 parameter type이 String이 맞는지
+     */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean isEmailAnnotation = parameter
+                .getParameterAnnotation(LogInUser.class) != null;
+        boolean isString = parameter
+                .getParameterType().equals(SessionUser.class);
+
+        return isEmailAnnotation && isString;
+    }
+
+    // arg에 실제 SessionUser의 email 속성 binding
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        return httpSession.getAttribute("user");
+    }
+}

--- a/src/main/java/com/recipetory/config/auth/dto/OAuthAttributeConverter.java
+++ b/src/main/java/com/recipetory/config/auth/dto/OAuthAttributeConverter.java
@@ -1,0 +1,19 @@
+package com.recipetory.config.auth.dto;
+
+import com.recipetory.config.auth.dto.OAuthAttributes;
+
+import java.util.Map;
+
+/**
+ * provider server에서 제공한 user attributes를
+ * recipetory에서 이용 가능한 OAuthAttributes로 convert합니다.
+ */
+@FunctionalInterface
+public interface OAuthAttributeConverter {
+    /**
+     * @param userNameAttributeName provider server에서 이용하는 id field
+     * @param attributes provider server에서 제공한 user attributes
+     * @return : recipetory에서 사용하는 {@link OAuthAttributes} 타입의 DTO
+     */
+    OAuthAttributes convert(String userNameAttributeName, Map<String,Object> attributes);
+}

--- a/src/main/java/com/recipetory/config/auth/dto/OAuthAttributes.java
+++ b/src/main/java/com/recipetory/config/auth/dto/OAuthAttributes.java
@@ -1,0 +1,44 @@
+package com.recipetory.config.auth.dto;
+
+import com.recipetory.user.domain.Role;
+import com.recipetory.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Builder
+@Getter
+public class OAuthAttributes {
+    private String email;
+    private String name;
+    private String provider;
+    private String userNameAttributeName;
+    private Map<String,Object> attributes;
+
+    /**
+     * @param provider name of provider
+     * @param attributes provider specific attributes
+     * @return general attributes
+     * */
+    public static OAuthAttributes of(String provider,
+                                     String userNameAttributeName,
+                                     Map<String,Object> attributes) {
+        System.out.println(attributes);
+        OAuthProvider foundProvider = OAuthProvider.findProvider(provider);
+        return foundProvider.convert(userNameAttributeName, attributes);
+    }
+
+    /**
+     * 회원가입 user entity
+     * default {@link Role} : GUEST
+     * */
+    public User toEntity() {
+        return User.builder()
+                .email(this.email)
+                .name(this.name)
+                .provider(this.provider)
+                .role(Role.GUEST)
+                .build();
+    }
+}

--- a/src/main/java/com/recipetory/config/auth/dto/OAuthAttributes.java
+++ b/src/main/java/com/recipetory/config/auth/dto/OAuthAttributes.java
@@ -24,7 +24,6 @@ public class OAuthAttributes {
     public static OAuthAttributes of(String provider,
                                      String userNameAttributeName,
                                      Map<String,Object> attributes) {
-        System.out.println(attributes);
         OAuthProvider foundProvider = OAuthProvider.findProvider(provider);
         return foundProvider.convert(userNameAttributeName, attributes);
     }

--- a/src/main/java/com/recipetory/config/auth/dto/OAuthProvider.java
+++ b/src/main/java/com/recipetory/config/auth/dto/OAuthProvider.java
@@ -31,6 +31,17 @@ public enum OAuthProvider {
                 .provider("naver")
                 .attributes(response)
                 .build();
+    }),
+    KAKAO("kakao", (userNameAttributeName, attributes) -> {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+        return OAuthAttributes.builder()
+                .email((String) account.get("email"))
+                .name((String) ((Map<String, Object>) account.get("profile")).get("nickname"))
+                .userNameAttributeName("id")
+                .attributes(attributes)
+                .provider("kakao")
+                .build();
     });
 
     private final String name;

--- a/src/main/java/com/recipetory/config/auth/dto/OAuthProvider.java
+++ b/src/main/java/com/recipetory/config/auth/dto/OAuthProvider.java
@@ -6,6 +6,10 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import java.util.Arrays;
 import java.util.Map;
 
+/**
+ * oauth provider와
+ * 그에 맞는 attribute converter를 제공합니다.
+ * */
 @RequiredArgsConstructor
 public enum OAuthProvider {
     GOOGLE("google", (userNameAttributeName, attributes) -> {
@@ -15,6 +19,17 @@ public enum OAuthProvider {
                 .userNameAttributeName(userNameAttributeName)
                 .provider("google")
                 .attributes(attributes)
+                .build();
+    }),
+    NAVER("naver", (userNameAttributeName, attributes) -> {
+        Map<String, Object> response = (Map<String, Object>) attributes.get(userNameAttributeName);
+
+        return OAuthAttributes.builder()
+                .email((String) response.get("email"))
+                .name((String) response.get("nickname"))
+                .userNameAttributeName("id")
+                .provider("naver")
+                .attributes(response)
                 .build();
     });
 

--- a/src/main/java/com/recipetory/config/auth/dto/OAuthProvider.java
+++ b/src/main/java/com/recipetory/config/auth/dto/OAuthProvider.java
@@ -1,0 +1,37 @@
+package com.recipetory.config.auth.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+import java.util.Arrays;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public enum OAuthProvider {
+    GOOGLE("google", (userNameAttributeName, attributes) -> {
+        return OAuthAttributes.builder()
+                .email((String) attributes.get("email"))
+                .name((String) attributes.get("name"))
+                .userNameAttributeName(userNameAttributeName)
+                .provider("google")
+                .attributes(attributes)
+                .build();
+    });
+
+    private final String name;
+    private final OAuthAttributeConverter converter;
+
+    public static OAuthProvider findProvider(String name) {
+        return Arrays.stream(OAuthProvider.values())
+                .filter(provider -> provider.hasEqualName(name)).findAny()
+                .orElseThrow(() -> new OAuth2AuthenticationException("유효하지 않은 provider : " + name));
+    }
+
+    public OAuthAttributes convert(String userNameAttributeName, Map<String, Object> attributes) {
+        return converter.convert(userNameAttributeName,attributes);
+    }
+
+    private boolean hasEqualName(String name) {
+        return this.name.equals(name);
+    }
+}

--- a/src/main/java/com/recipetory/config/auth/dto/SessionUser.java
+++ b/src/main/java/com/recipetory/config/auth/dto/SessionUser.java
@@ -1,0 +1,19 @@
+package com.recipetory.config.auth.dto;
+
+import com.recipetory.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SessionUser {
+    private String name;
+    private String email;
+
+    public static SessionUser fromEntity(User user) {
+        return SessionUser.builder()
+                .email(user.getEmail())
+                .name(user.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/recipetory/user/domain/Role.java
+++ b/src/main/java/com/recipetory/user/domain/Role.java
@@ -1,0 +1,17 @@
+package com.recipetory.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Role enum type for security
+ * */
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    ADMIN("ROLE_ADMIN"),
+    USER("ROLE_USER"),
+    GUEST("ROLE_GUEST");
+
+    private final String key;
+}

--- a/src/main/java/com/recipetory/user/domain/User.java
+++ b/src/main/java/com/recipetory/user/domain/User.java
@@ -1,14 +1,18 @@
 package com.recipetory.user.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 @Entity
 @Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "member")
 public class User {
     @Id

--- a/src/main/java/com/recipetory/user/domain/User.java
+++ b/src/main/java/com/recipetory/user/domain/User.java
@@ -1,0 +1,38 @@
+package com.recipetory.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@Entity
+@Builder
+@Getter
+@Table(name = "member")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private String imageUrl;
+
+    // OAuth2
+    @Column
+    private String provider;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    public GrantedAuthority createAuthority() {
+        return new SimpleGrantedAuthority(role.getKey());
+    }
+}

--- a/src/main/java/com/recipetory/user/domain/UserRepository.java
+++ b/src/main/java/com/recipetory/user/domain/UserRepository.java
@@ -1,0 +1,9 @@
+package com.recipetory.user.domain;
+
+import java.util.Optional;
+
+public interface UserRepository {
+    Optional<User> findByEmail(String email);
+
+    User save(User user);
+}

--- a/src/main/java/com/recipetory/user/infrastructure/UserJpaRepository.java
+++ b/src/main/java/com/recipetory/user/infrastructure/UserJpaRepository.java
@@ -1,0 +1,10 @@
+package com.recipetory.user.infrastructure;
+
+import com.recipetory.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserJpaRepository extends JpaRepository<User,Long> {
+    Optional<User> findByEmail(String eamil);
+}

--- a/src/main/java/com/recipetory/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/com/recipetory/user/infrastructure/UserRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.recipetory.user.infrastructure;
+
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userJpaRepository.findByEmail(email);
+    }
+
+    @Override
+    public User save(User user) {
+        return userJpaRepository.save(user);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,12 +16,24 @@ spring:
             redirect-uri: ${NAVER_OAUTH_REDIRECT_URI}
             authorization-grant-type: authorization_code
             scope: email,nickname
+          kakao:
+            client-name: kakao
+            client-id: ${KAKAO_OAUTH_ID}
+            redirect-uri: ${KAKAO_OAUTH_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            scope: account_email,profile_nickname
         provider:
           naver:
             authorization-uri: https://nid.naver.com/oauth2.0/authorize
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
   h2:
     console:
       enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,25 @@
-
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_OAUTH_ID}
+            client-secret: ${GOOGLE_OAUTH_PW}
+            scope:
+              - email
+              - profile
+  h2:
+    console:
+      enabled: true
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:~/test
+    username: sa
+    password: 1234
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+    hibernate:
+      ddl-auto: update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,19 @@ spring:
             scope:
               - email
               - profile
+          naver:
+            client-name: naver
+            client-id: ${NAVER_OAUTH_ID}
+            client-secret: ${NAVER_OAUTH_PW}
+            redirect-uri: ${NAVER_OAUTH_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            scope: email,nickname
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
   h2:
     console:
       enabled: true


### PR DESCRIPTION
## 개요
- Spring Security, OAuth2 클라이언트 이용해서 소셜 회원 가입 및 로그인 기능 구현했습니다.
- 최초로 가입한 사람은 `ROLE_GUEST` 권한을 갖도록 했습니다. 
- provider(google 등)에서 받은 provider 자체, 유저 email, name(닉네임) 정보를 DB에 저장하도록 구성했습니다.
- 회원 프로필 업데이트 기능은 레시피 업로드 등 기본 기능 구현한 후에 추가할 예정입니다!

## 작업사항
- OAuth provider로 google, naver, kakao 두었습니다.
- converter interface를 사용해 각 인증 서버에서 제공한 사용자 정보를 프로젝트에서 사용가능한 `OAuthAttributes`로 변환시켰습니다. [converter 구현](https://github.com/f-lab-edu/recipetory/pull/3/commits/de8991e56b26127cf426788db06e1155038ec01f#diff-193b2230973043c71442e3af1fc735e447e56a74e71c4e6a8034f89904063727)을 위해 enum 다형성 기능 이용했어요!
- spring security 6.1.2에서 [security filter chain 람다 관련 변경사항](https://docs.spring.io/spring-security/reference/migration-7/configuration.html)과 [spring mvc와 통합을 위한 RequestMatcher 변경사항](https://docs.spring.io/spring-security/reference/servlet/integrations/mvc.html#mvc-requestmatcher) 이슈 있어서, [예시 코드](https://github.com/spring-projects/spring-security-samples/tree/main/servlet/java-configuration/authentication/preauth) 참고하여 security configuration 진행했습니다..
- `@LogInUser` 어노테이션을 통해 핸들러 메소드 인자로 로그인한 세션 정보를 가져올 수 있는 [작업](https://github.com/f-lab-edu/recipetory/commit/dd99178389819c281a9f10a98289a55919a6d883) 진행했습니다.

## 비고
- 이게 프로젝트 첫 PR인데요, PR이나 커밋 단위에 대해 맞춰보는게 필요한 것 같습니다 ㅜㅜ!
- Entity `@Id`에 대해 고민이 필요합니다..