### PR TITLE
회원 정보 수정 및 유저 프로필 조회

### DIFF
--- a/src/main/java/com/recipetory/config/auth/SecurityConfiguration.java
+++ b/src/main/java/com/recipetory/config/auth/SecurityConfiguration.java
@@ -25,6 +25,7 @@ public class SecurityConfiguration {
         http
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(mvc.pattern("/check")).authenticated()
+                        .requestMatchers(mvc.pattern("/profile")).authenticated()
                         .requestMatchers(mvc.pattern(HttpMethod.POST,"/recipe")).hasAuthority(Role.USER.getKey())
                         .requestMatchers(mvc.pattern(HttpMethod.POST,"/bookmark/**")).authenticated()
                         .requestMatchers(mvc.pattern(HttpMethod.DELETE,"/bookmark/**")).authenticated()

--- a/src/main/java/com/recipetory/recipe/domain/Recipe.java
+++ b/src/main/java/com/recipetory/recipe/domain/Recipe.java
@@ -1,16 +1,16 @@
 package com.recipetory.recipe.domain;
 
-import com.recipetory.bookmark.domain.exception.CannotBookMarkException;
 import com.recipetory.ingredient.domain.RecipeIngredient;
 import com.recipetory.step.domain.Step;
 import com.recipetory.user.domain.User;
-import com.recipetory.user.domain.exception.NotOwnerException;
 import com.recipetory.utils.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.Objects;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/recipetory/recipe/domain/RecipeStatistics.java
+++ b/src/main/java/com/recipetory/recipe/domain/RecipeStatistics.java
@@ -19,11 +19,15 @@ public class RecipeStatistics {
 
     @Column
     private int bookMarkCount;
-
+    
     public void addBookMarkCount() {
         this.bookMarkCount += 1;
     }
     public void subtractBookMarkCount() {
         this.bookMarkCount -= 1;
+    }
+
+    public String getRatingFormat() {
+        return String.format("%.1f",ratings / 10.0);
     }
 }

--- a/src/main/java/com/recipetory/recipe/presentation/dto/RecipeTitleDto.java
+++ b/src/main/java/com/recipetory/recipe/presentation/dto/RecipeTitleDto.java
@@ -1,0 +1,34 @@
+package com.recipetory.recipe.presentation.dto;
+
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.recipe.domain.RecipeInfo;
+import com.recipetory.recipe.domain.RecipeStatistics;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class RecipeTitleDto {
+    private Long id;
+    private String title;
+    private String description;
+    private int viewCount;
+    private String ratings;
+
+    public static RecipeTitleDto fromEntity(Recipe recipe) {
+        RecipeInfo recipeInfo = recipe.getRecipeInfo();
+        RecipeStatistics recipeStatistics = recipe.getRecipeStatistics();
+
+        return RecipeTitleDto.builder()
+                .id(recipe.getId())
+                .title(recipe.getTitle())
+                .description(recipeInfo.getDescription())
+                .viewCount(recipeStatistics.getViewCount())
+                .ratings(recipeStatistics.getRatingFormat())
+                .build();
+    }
+}

--- a/src/main/java/com/recipetory/user/application/UserService.java
+++ b/src/main/java/com/recipetory/user/application/UserService.java
@@ -1,0 +1,36 @@
+package com.recipetory.user.application;
+
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.UserKeyType;
+import com.recipetory.user.domain.UserRepository;
+import com.recipetory.user.domain.exception.UserNotFoundException;
+import com.recipetory.user.presentation.dto.EditUserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User editUser(String logInEmail, EditUserDto editUserDto) {
+        User editUser = getUserByEmail(logInEmail);
+        editUser.editName(editUserDto.getName());
+
+        return editUser;
+    }
+
+    @Transactional
+    public User getUserByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() ->
+                        new UserNotFoundException(UserKeyType.EMAIL, email));
+    }
+
+    @Transactional
+    public User getUserById(Long id) {
+        return userRepository.findById(id).orElseThrow(() ->
+            new UserNotFoundException(UserKeyType.ID, String.valueOf(id)));
+    }
+}

--- a/src/main/java/com/recipetory/user/domain/User.java
+++ b/src/main/java/com/recipetory/user/domain/User.java
@@ -2,6 +2,7 @@ package com.recipetory.user.domain;
 
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.user.domain.exception.InvalidUserRoleException;
+import com.recipetory.utils.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +19,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "member")
-public class User {
+public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -47,7 +48,7 @@ public class User {
             length = 15)
     private Role role;
 
-    public GrantedAuthority createAuthority() {
+    public GrantedAuthority getAuthority() {
         return new SimpleGrantedAuthority(role.getKey());
     }
 
@@ -55,5 +56,10 @@ public class User {
         if (role != requiredRole) {
             throw new InvalidUserRoleException(id, role, requiredRole);
         }
+    }
+
+    public void editName(String name) {
+        this.name = name;
+        this.role = Role.USER;
     }
 }

--- a/src/main/java/com/recipetory/user/presentation/dto/EditUserDto.java
+++ b/src/main/java/com/recipetory/user/presentation/dto/EditUserDto.java
@@ -1,0 +1,30 @@
+package com.recipetory.user.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor
+public class EditUserDto {
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]{2,14}$",
+            message = "닉네임은 1자 이상 15자 이하의 한글, 영문, 숫자로만 이뤄져야 합니다.")
+    @NotBlank
+    @NotNull
+    private String name;
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class Response {
+        private Long id;
+        private String oldName;
+        private String newName;
+    }
+}

--- a/src/main/java/com/recipetory/user/presentation/dto/ProfileDto.java
+++ b/src/main/java/com/recipetory/user/presentation/dto/ProfileDto.java
@@ -1,0 +1,33 @@
+package com.recipetory.user.presentation.dto;
+
+import com.recipetory.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+@Builder
+@NoArgsConstructor
+public class ProfileDto {
+    private String name;
+    private String email;
+    private LocalDateTime createdAt;
+    private String provider;
+    private String profileImage = "";
+    private int recipeNumber = 0;
+
+    public static ProfileDto fromEntity(User user) {
+        return ProfileDto.builder()
+                .name(user.getName())
+                .email(user.getEmail())
+                .createdAt(user.getCreatedAt())
+                .provider(user.getProvider())
+                .profileImage(user.getImageUrl())
+                .recipeNumber(user.getRecipes().size())
+                .build();
+    }
+}

--- a/src/main/java/com/recipetory/user/presentation/dto/UserHomeDto.java
+++ b/src/main/java/com/recipetory/user/presentation/dto/UserHomeDto.java
@@ -1,0 +1,32 @@
+package com.recipetory.user.presentation.dto;
+
+import com.recipetory.recipe.presentation.dto.RecipeTitleDto;
+import com.recipetory.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class UserHomeDto {
+    private String name;
+    private String profileImage = "";
+    private List<RecipeTitleDto> recipes = new ArrayList<>();
+
+    public static UserHomeDto fromEntity(User user) {
+        List<RecipeTitleDto> recipeTitleDtos = user.getRecipes()
+                .stream().map(RecipeTitleDto::fromEntity).toList();
+
+        return UserHomeDto.builder()
+                .name(user.getName())
+                .profileImage(user.getImageUrl())
+                .recipes(recipeTitleDtos)
+                .build();
+    }
+}

--- a/src/test/java/com/recipetory/user/service/UserServiceTest.java
+++ b/src/test/java/com/recipetory/user/service/UserServiceTest.java
@@ -1,0 +1,67 @@
+package com.recipetory.user.service;
+
+import com.recipetory.TestRepositoryConfig;
+import com.recipetory.user.application.UserService;
+import com.recipetory.user.domain.Role;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.UserRepository;
+import com.recipetory.user.domain.exception.UserNotFoundException;
+import com.recipetory.user.presentation.dto.EditUserDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Import(TestRepositoryConfig.class)
+@DataJpaTest
+public class UserServiceTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    private UserService userService;
+
+    @BeforeEach
+    public void setUp() {
+        userService = new UserService(userRepository);
+    }
+
+    @Test
+    @DisplayName("수정한 유저의 이름과 Role은 잘 반영된다.")
+    public void testEditUser() {
+        // given : testEmail, "test" name 을 가진 GUEST 유저
+        String testEmail = "test@test.com";
+        userRepository.save(User.builder()
+                .name("test")
+                .email("test@test.com")
+                .role(Role.GUEST).build());
+
+        // when : "new test"로 edit
+        String newName = "new test";
+        EditUserDto editUserDto = new EditUserDto(newName);
+        userService.editUser(testEmail,editUserDto);
+
+        // then : 이름이 "new test", 권한이 USER 유저로 바뀌었다.
+        User foundUser = userRepository.findByEmail(testEmail)
+                .orElseThrow();
+        assertEquals(newName, foundUser.getName());
+        assertEquals(foundUser.getRole(),Role.USER);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저 key로 유저를 찾을 수 없다.")
+    public void testEmailNotFound() {
+        // given : 현재 DB엔 유저가 없는 상태
+
+        // when,then : 아무 이메일과 아이디로 유저 찾았을 경우 UserNotFoundException
+        assertThrows(UserNotFoundException.class, () -> {
+            userService.getUserByEmail("email@test.com");
+        });
+        assertThrows(UserNotFoundException.class, () -> {
+            userService.getUserById(1234L);
+        });
+    }
+}


### PR DESCRIPTION
## 개요
- 회원 정보를 수정하는 일 , 동시에 유저 권한(role)도 업데이트 할 수 있는 기능을 추가했습니다.
- 유저 정보 조회 기능도 추가하였습니다!
- 회원가입한 유저는 `GUEST`이고, 사용할 name을 수정해서 [`USER` role을 가져야만 레시피를 등록할 수 있다] ~~ 정도로 생각했는데 쓸데없는 기능이었는지 ㅜㅜ 생각이 드네요.

## 작업사항
- 로그인된 본인의 프로필을 조회하는 `ProfileDto`와 `"/{userId}"`를 통해 특정 id의 유저를 조회하는 `UserHomeDto`를 나눴습니다
- `PUT` 메소드로 회원정보를 수정할 때마다 security context의 role을 같이 업데이트 하도록 구성했습니다.

## 고민?
- security configuration에 `AccessDeniedHandler`를 만들려고 했는데,, 이상하게 로그인단만 건드리면 시간이 걸려서 배보다 배꼽이 커지는 상황을 막기 위해 수요일 오후 전까지 태그와 댓글까지는 다 만들려고 해요 !!!