### PR TITLE
레시피 태그 기능 추가

### DIFF
--- a/src/main/java/com/recipetory/config/auth/LocalSecurityConfig.java
+++ b/src/main/java/com/recipetory/config/auth/LocalSecurityConfig.java
@@ -1,11 +1,9 @@
 package com.recipetory.config.auth;
 
-import com.recipetory.user.domain.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -15,9 +13,8 @@ import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@Profile("prod")
-public class SecurityConfiguration {
-
+@Profile("local")
+public class LocalSecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
 
     // since spring security 6.1.2 : MvcRequestMatcher.Builder
@@ -26,19 +23,6 @@ public class SecurityConfiguration {
     SecurityFilterChain filterChain(HttpSecurity http, MvcRequestMatcher.Builder mvc) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(mvc.pattern("/check")).authenticated()
-                        .requestMatchers(mvc.pattern("/profile")).authenticated()
-                        .requestMatchers(mvc.pattern(HttpMethod.POST,"/recipe")).hasAuthority(Role.USER.getKey())
-                        .requestMatchers(mvc.pattern(HttpMethod.POST,"/bookmark/**")).authenticated()
-                        .requestMatchers(mvc.pattern(HttpMethod.DELETE,"/bookmark/**")).authenticated()
-                        .requestMatchers(mvc.pattern("/follow/**")).authenticated()
-                        .requestMatchers(mvc.pattern(HttpMethod.POST,"/tags/**")).hasAuthority(Role.USER.getKey())
-                        .requestMatchers(mvc.pattern(HttpMethod.DELETE,"/tags/**")).hasAuthority(Role.USER.getKey())
-                        // 조회(GET)는 permitAll, 나머지는 authenticated()
-                        .requestMatchers(mvc.pattern(HttpMethod.GET,"/comments/**")).permitAll()
-                        .requestMatchers(mvc.pattern("/comments/**")).authenticated()
-                        .requestMatchers(mvc.pattern(HttpMethod.GET,"/reviews/**")).permitAll()
-                        .requestMatchers(mvc.pattern("/reviews/**")).authenticated()
                         .anyRequest().permitAll())
                 // for h2-console
                 .headers(headers -> headers.frameOptions(option -> option.disable()))

--- a/src/main/java/com/recipetory/recipe/application/RecipeService.java
+++ b/src/main/java/com/recipetory/recipe/application/RecipeService.java
@@ -40,6 +40,7 @@ public class RecipeService {
         // 3. set basic relations
         recipe.setBasicRelations(author,recipeIngredients);
         recipe.getSteps().forEach(step -> step.setRecipe(recipe));
+        recipe.getTags().forEach(tag -> tag.setRecipe(recipe));
 
         // 4. save(persist) -> cascade
         return recipeRepository.save(recipe);

--- a/src/main/java/com/recipetory/recipe/domain/Recipe.java
+++ b/src/main/java/com/recipetory/recipe/domain/Recipe.java
@@ -2,6 +2,7 @@ package com.recipetory.recipe.domain;
 
 import com.recipetory.ingredient.domain.RecipeIngredient;
 import com.recipetory.step.domain.Step;
+import com.recipetory.tag.domain.Tag;
 import com.recipetory.user.domain.User;
 import com.recipetory.utils.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -48,6 +49,12 @@ public class Recipe extends BaseTimeEntity {
             mappedBy = "recipe",
             orphanRemoval = true)
     private List<RecipeIngredient> ingredients;
+
+    @OneToMany(targetEntity = Tag.class,
+            cascade = CascadeType.ALL,
+            mappedBy = "recipe",
+            orphanRemoval = true)
+    private List<Tag> tags;
 
     // set basic relations for creation
     public void setBasicRelations(User author,

--- a/src/main/java/com/recipetory/recipe/presentation/dto/CreateRecipeDto.java
+++ b/src/main/java/com/recipetory/recipe/presentation/dto/CreateRecipeDto.java
@@ -4,6 +4,8 @@ import com.recipetory.ingredient.presentation.dto.RecipeIngredientDto;
 import com.recipetory.recipe.domain.*;
 import com.recipetory.step.domain.Step;
 import com.recipetory.step.presentation.dto.CreateStepDto;
+import com.recipetory.tag.domain.Tag;
+import com.recipetory.tag.presentation.dto.TagDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -34,8 +36,7 @@ public class CreateRecipeDto {
         private List<RecipeIngredientDto> ingredients
                 = new ArrayList<>();
 
-        // TODO : Tag
-
+        private List<TagDto> tags = new ArrayList<>();
 
         // recipe entity without m:n relation
         public Recipe toEntity() {
@@ -51,10 +52,16 @@ public class CreateRecipeDto {
                     .map(CreateStepDto.Request::toEntity)
                     .toList();
 
+            // '일대다'로 종속된 tags
+            List<Tag> tags = this.tags.stream()
+                    .map(TagDto::toEntity)
+                    .toList();
+
             return Recipe.builder()
                     .title(title)
                     .recipeInfo(recipeInfo)
                     .recipeStatistics(new RecipeStatistics()) // statistics : 항상 초기값
+                    .tags(tags)
                     .steps(steps)
                     .build();
         }
@@ -73,6 +80,7 @@ public class CreateRecipeDto {
 
         private List<CreateStepDto.Response> steps;
         private List<RecipeIngredientDto> ingredients;
+        private List<TagDto> tags;
 
         public static CreateRecipeDto.Response fromEntity(Recipe recipe) {
             RecipeInfo recipeInfo = recipe.getRecipeInfo();
@@ -83,12 +91,15 @@ public class CreateRecipeDto {
             List<RecipeIngredientDto> ingredients = recipe.getIngredients().stream()
                     .map(RecipeIngredientDto::fromEntity)
                     .toList();
+            List<TagDto> tags = recipe.getTags().stream()
+                    .map(TagDto::fromEntity).toList();
 
             return Response.builder()
                     .title(recipe.getTitle())
                     .recipeInfo(recipeInfo)
                     .steps(steps)
                     .ingredients(ingredients)
+                    .tags(tags)
                     .build();
         }
     }

--- a/src/main/java/com/recipetory/recipe/presentation/dto/RecipeListDto.java
+++ b/src/main/java/com/recipetory/recipe/presentation/dto/RecipeListDto.java
@@ -1,0 +1,23 @@
+package com.recipetory.recipe.presentation.dto;
+
+import com.recipetory.recipe.domain.Recipe;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecipeListDto {
+    private List<RecipeTitleDto> recipes = new ArrayList<>();
+
+    public static RecipeListDto fromEntityList(List<Recipe> recipes) {
+        List<RecipeTitleDto> recipeDtos = recipes.stream()
+                .map(RecipeTitleDto::fromEntity).toList();
+
+        return new RecipeListDto(recipeDtos);
+    }
+}

--- a/src/main/java/com/recipetory/recipe/presentation/dto/RecipeTitleDto.java
+++ b/src/main/java/com/recipetory/recipe/presentation/dto/RecipeTitleDto.java
@@ -1,5 +1,6 @@
 package com.recipetory.recipe.presentation.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.recipe.domain.RecipeInfo;
 import com.recipetory.recipe.domain.RecipeStatistics;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RecipeTitleDto {
     private Long id;
     private String title;

--- a/src/main/java/com/recipetory/tag/application/TagService.java
+++ b/src/main/java/com/recipetory/tag/application/TagService.java
@@ -1,0 +1,109 @@
+package com.recipetory.tag.application;
+
+import com.recipetory.recipe.application.RecipeService;
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.tag.domain.Tag;
+import com.recipetory.tag.domain.TagName;
+import com.recipetory.tag.domain.TagRepository;
+import com.recipetory.tag.presentation.dto.TagDto;
+import com.recipetory.user.application.UserService;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.exception.NotOwnerException;
+import com.recipetory.utils.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+    private final TagRepository tagRepository;
+    private final RecipeService recipeService;
+    private final UserService userService;
+
+    /**
+     * 인자로 들어온 TagDto의 연관 관계를 설정한 뒤 save한다.
+     * @param tagDto
+     * @param logInEmail 현재 로그인한 유저
+     * @return 생성된 {@link TagDto}
+     */
+    @Transactional
+    public TagDto addTag(TagDto tagDto, Long recipeId, String logInEmail) {
+        User author = userService.getUserByEmail(logInEmail);
+        Recipe recipe = recipeService.getRecipeById(recipeId);
+
+        // 레시피 주인 검사
+        validateRecipeAuthor(recipe,author);
+
+        // 태그는 한 번만 반영 (idempotent)
+        Tag saved = tagRepository.findByRecipeAndTagName(recipe, tagDto.getTagName())
+                .orElseGet(() -> {
+                    Tag tag = tagDto.toEntity();
+                    tag.setRecipe(recipe);
+                    return tagRepository.save(tag);
+                });
+
+        return TagDto.fromEntity(saved);
+    }
+
+    /**
+     * 특정 tagName을 가진 recipe들을 찾는다.
+     * @param tagName 찾고자 하는 tag
+     * @return 해당 tagName을 가진 레시피 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<Recipe> getRecipeByTag(TagName tagName) {
+        List<Tag> foundTags = tagRepository.findByTagName(tagName);
+        return foundTags.stream()
+                .map(Tag::getRecipe).toList();
+    }
+
+    /**
+     * recipeId의 레시피가 가진 tag 리스트를 dto로 반환한다.
+     * @param recipeId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public List<TagDto> getTagByRecipeId(Long recipeId) {
+        Recipe recipe = recipeService.getRecipeById(recipeId);
+        List<Tag> found = tagRepository.findByRecipe(recipe);
+
+        return found.stream()
+                .map(TagDto::fromEntity).toList();
+    }
+
+    /**
+     * 특정 id를 가진 tag를 삭제한다.
+     * @param tagId
+     * @param logInEmail 현재 로그인하여 세션에 저장된 유저 email
+     */
+    @Transactional
+    public void deleteTag(Long tagId, String logInEmail) {
+        User author = userService.getUserByEmail(logInEmail);
+        Tag foundTag = tagRepository.findById(tagId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Tag",String.valueOf(tagId)));
+        Recipe recipe = foundTag.getRecipe();
+
+        // 레시피 주인만이 태그 삭제 가능
+        validateRecipeAuthor(recipe,author);
+
+        tagRepository.delete(foundTag);
+    }
+
+    /**
+     * 레시피의 작성자가 맞는지 확인한다.
+     * @param recipe target recipe
+     * @param author expected author
+     * @throws NotOwnerException author 아닐 경우
+     */
+    @Transactional(readOnly = true)
+    private void validateRecipeAuthor(Recipe recipe, User author) {
+        if (!recipe.isSameAuthor(author)) {
+            throw new NotOwnerException(author.getId(), recipe.getAuthor().getId(),
+                    "Recipe", String.valueOf(recipe.getId()));
+        }
+    }
+}

--- a/src/main/java/com/recipetory/tag/domain/Tag.java
+++ b/src/main/java/com/recipetory/tag/domain/Tag.java
@@ -1,0 +1,32 @@
+package com.recipetory.tag.domain;
+
+import com.recipetory.recipe.domain.Recipe;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TagName tagName;
+
+    @ManyToOne(targetEntity = Recipe.class)
+    @JoinColumn(name = "recipe_id",
+            updatable = false)
+    private Recipe recipe;
+
+    public void setRecipe(Recipe recipe) {
+        this.recipe = recipe;
+    }
+}

--- a/src/main/java/com/recipetory/tag/domain/TagName.java
+++ b/src/main/java/com/recipetory/tag/domain/TagName.java
@@ -1,0 +1,42 @@
+package com.recipetory.tag.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum TagName {
+    MAIN("주요리",TagType.TYPE),
+    SIDE("반찬",TagType.TYPE),
+    RICE("밥",TagType.TYPE),
+    SOUP("국",TagType.TYPE),
+    SALTED("젓갈/장류",TagType.TYPE),
+    SAUCE("소스류",TagType.TYPE),
+    NOODLE("면",TagType.TYPE),
+    SALAD("샐러드",TagType.TYPE),
+    FUSION("퓨전",TagType.TYPE),
+    BREAD("빵",TagType.TYPE),
+    DESSERT("디저트", TagType.TYPE),
+    DRINK("음료",TagType.TYPE),
+    CANDY("과자",TagType.TYPE),
+
+    NORMAL("일상",TagType.SITUATION),
+    SIMPLE("간단한",TagType.SITUATION),
+    LUNCHBOX("도시락",TagType.SITUATION),
+    MIDNIGHT("야식",TagType.SITUATION),
+    DIET("다이어트",TagType.SITUATION),
+    SNACK("간식",TagType.SITUATION),
+    ENTERTAIN("손님 접대",TagType.SITUATION),
+    HEALTH("헬스/건강식",TagType.SITUATION),
+
+    FRY("튀김",TagType.METHOD),
+    BOIL("삶음",TagType.METHOD),
+    STEAM("찜",TagType.METHOD),
+    ROAST("구이",TagType.METHOD),
+    BIBIM("비빔/무침",TagType.METHOD),
+    JORIM("조림",TagType.METHOD),
+    RAW("회/날음식",TagType.METHOD);
+
+    private final String korean;
+    private final TagType tagType;
+}

--- a/src/main/java/com/recipetory/tag/domain/TagRepository.java
+++ b/src/main/java/com/recipetory/tag/domain/TagRepository.java
@@ -1,0 +1,20 @@
+package com.recipetory.tag.domain;
+
+import com.recipetory.recipe.domain.Recipe;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TagRepository {
+    Tag save(Tag tag);
+
+    List<Tag> findByRecipe(Recipe recipe);
+
+    List<Tag> findByTagName(TagName tagName);
+
+    Optional<Tag> findById(Long id);
+
+    Optional<Tag> findByRecipeAndTagName(Recipe recipe, TagName tagName);
+
+    void delete(Tag tag);
+}

--- a/src/main/java/com/recipetory/tag/domain/TagType.java
+++ b/src/main/java/com/recipetory/tag/domain/TagType.java
@@ -1,0 +1,14 @@
+package com.recipetory.tag.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum TagType {
+    TYPE("음식 종류별"),
+    METHOD("조리 방법별"),
+    SITUATION("상황별");
+
+    private final String description;
+}

--- a/src/main/java/com/recipetory/tag/infrastructure/TagJpaRepository.java
+++ b/src/main/java/com/recipetory/tag/infrastructure/TagJpaRepository.java
@@ -1,0 +1,17 @@
+package com.recipetory.tag.infrastructure;
+
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.tag.domain.Tag;
+import com.recipetory.tag.domain.TagName;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TagJpaRepository extends JpaRepository<Tag,Long> {
+    List<Tag> findByRecipe(Recipe recipe);
+
+    List<Tag> findByTagName(TagName tagName);
+
+    Optional<Tag> findByRecipeAndTagName(Recipe recipe, TagName tagName);
+}

--- a/src/main/java/com/recipetory/tag/infrastructure/TagRepositoryImpl.java
+++ b/src/main/java/com/recipetory/tag/infrastructure/TagRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.recipetory.tag.infrastructure;
+
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.tag.domain.Tag;
+import com.recipetory.tag.domain.TagName;
+import com.recipetory.tag.domain.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class TagRepositoryImpl implements TagRepository {
+    private final TagJpaRepository tagJpaRepository;
+
+    @Override
+    public Tag save(Tag tag) {
+        return tagJpaRepository.save(tag);
+    }
+
+    @Override
+    public List<Tag> findByRecipe(Recipe recipe) {
+        return tagJpaRepository.findByRecipe(recipe);
+    }
+
+    @Override
+    public List<Tag> findByTagName(TagName tagName) {
+        return tagJpaRepository.findByTagName(tagName);
+    }
+
+    @Override
+    public Optional<Tag> findById(Long id) {
+        return tagJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Tag> findByRecipeAndTagName(Recipe recipe, TagName tagName) {
+        return tagJpaRepository.findByRecipeAndTagName(recipe, tagName);
+    }
+
+    @Override
+    public void delete(Tag tag) {
+        tagJpaRepository.delete(tag);
+    }
+}

--- a/src/main/java/com/recipetory/tag/presentation/TagController.java
+++ b/src/main/java/com/recipetory/tag/presentation/TagController.java
@@ -1,0 +1,81 @@
+package com.recipetory.tag.presentation;
+
+import com.recipetory.config.auth.argumentresolver.LogInUser;
+import com.recipetory.config.auth.dto.SessionUser;
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.recipe.presentation.dto.RecipeListDto;
+import com.recipetory.tag.application.TagService;
+import com.recipetory.tag.domain.TagName;
+import com.recipetory.tag.presentation.dto.TagDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TagController {
+    private final TagService tagService;
+
+    /**
+     * recipeId에 해당하는 레시피에 태그를 추가한다
+     * @param tagDto
+     * @param logInUser
+     * @return
+     */
+    @PostMapping("/tags/{recipeId}")
+    public ResponseEntity<TagDto> createTag(
+            @Valid @RequestBody TagDto tagDto,
+            @PathVariable("recipeId") Long recipeId,
+            @LogInUser SessionUser logInUser
+    ) {
+        TagDto saved = tagService.addTag(
+                tagDto, recipeId, logInUser.getEmail());
+        return ResponseEntity.ok(saved);
+    }
+
+    /**
+     * 특정 tag의 레시피를 검색한다
+     * @param tagName
+     * @return
+     */
+    @GetMapping("/tags")
+    public ResponseEntity<RecipeListDto> getRecipesByTagName(
+            @RequestParam(name = "tag", required = true) TagName tagName
+    ) {
+        List<Recipe> recipes = tagService.getRecipeByTag(tagName);
+        return ResponseEntity.ok(RecipeListDto.fromEntityList(recipes));
+    }
+
+    /**
+     * 특정 레시피의 태그 목록을 불러온다.
+     * @param recipeId
+     * @return
+     */
+    @GetMapping("/recipes/{recipeId}/tags")
+    public ResponseEntity<List<TagDto>> getTagOfRecipe(
+            @PathVariable("recipeId") Long recipeId
+    ) {
+        List<TagDto> tagDtos = tagService.getTagByRecipeId(recipeId);
+        return ResponseEntity.ok(tagDtos);
+    }
+
+    /**
+     * tagId에 해당하는 태그를 삭제한다
+     * @param tagId
+     * @param logInUser
+     * @return
+     */
+    @DeleteMapping("/tags/{tagId}")
+    public ResponseEntity<Void> deleteTagById(
+            @PathVariable(name = "tagId") Long tagId,
+            @LogInUser SessionUser logInUser
+    ) {
+        String logInEmail = logInUser.getEmail();
+        tagService.deleteTag(tagId, logInEmail);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/recipetory/tag/presentation/dto/TagDto.java
+++ b/src/main/java/com/recipetory/tag/presentation/dto/TagDto.java
@@ -1,0 +1,36 @@
+package com.recipetory.tag.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.recipetory.tag.domain.Tag;
+import com.recipetory.tag.domain.TagName;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TagDto {
+    private Long tagId;
+
+    @NotNull
+    private TagName tagName;
+
+    public Tag toEntity() {
+        System.out.println(tagName);
+        return Tag.builder()
+                .tagName(tagName)
+                .build();
+    }
+
+    public static TagDto fromEntity(Tag tag) {
+        return TagDto.builder()
+                .tagId(tag.getId())
+                .tagName(tag.getTagName())
+                .build();
+    }
+}

--- a/src/test/java/com/recipetory/TestRepositoryConfig.java
+++ b/src/test/java/com/recipetory/TestRepositoryConfig.java
@@ -18,6 +18,12 @@ import com.recipetory.reply.infrastructure.comment.CommentJpaRepository;
 import com.recipetory.reply.infrastructure.comment.CommentRepositoryImpl;
 import com.recipetory.reply.infrastructure.review.ReviewJpaRepository;
 import com.recipetory.reply.infrastructure.review.ReviewRepositoryImpl;
+import com.recipetory.step.domain.StepRepository;
+import com.recipetory.step.infrastructure.StepJpaRepository;
+import com.recipetory.step.infrastructure.StepRepositoryImpl;
+import com.recipetory.tag.domain.TagRepository;
+import com.recipetory.tag.infrastructure.TagJpaRepository;
+import com.recipetory.tag.infrastructure.TagRepositoryImpl;
 import com.recipetory.user.domain.UserRepository;
 import com.recipetory.user.domain.follow.FollowRepository;
 import com.recipetory.user.infrastructure.FollowJpaRepository;
@@ -74,5 +80,17 @@ public class TestRepositoryConfig {
     public ReviewRepository reviewRepository(
             ReviewJpaRepository reviewJpaRepository) {
         return new ReviewRepositoryImpl(reviewJpaRepository);
+    }
+
+    @Bean
+    public TagRepository tagRepository(
+            TagJpaRepository tagJpaRepository) {
+        return new TagRepositoryImpl(tagJpaRepository);
+    }
+
+    @Bean
+    public StepRepository stepRepository(
+            StepJpaRepository stepJpaRepository) {
+        return new StepRepositoryImpl(stepJpaRepository);
     }
 }

--- a/src/test/java/com/recipetory/tag/application/TagServiceTest.java
+++ b/src/test/java/com/recipetory/tag/application/TagServiceTest.java
@@ -1,0 +1,147 @@
+package com.recipetory.tag.application;
+
+import com.recipetory.TestRepositoryConfig;
+import com.recipetory.TestServiceConfig;
+import com.recipetory.recipe.application.RecipeService;
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.tag.domain.TagName;
+import com.recipetory.tag.domain.TagRepository;
+import com.recipetory.tag.presentation.dto.TagDto;
+import com.recipetory.user.application.UserService;
+import com.recipetory.user.domain.Role;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.UserRepository;
+import com.recipetory.user.domain.exception.NotOwnerException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DataJpaTest
+@Import({TestServiceConfig.class, TestRepositoryConfig.class})
+public class TagServiceTest {
+    private TagService tagService;
+    @Autowired
+    private TagRepository tagRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private RecipeService recipeService;
+
+    User testUser;
+    String testEmail = "test@test.com";
+
+    @BeforeEach
+    void setUp() {
+        tagService = new TagService(tagRepository, recipeService, userService);
+        testUser = userRepository.save(User.builder()
+                        .name("test").email(testEmail).role(Role.USER).build());
+    }
+
+    @Test
+    @DisplayName("레시피 작성자는 태그를 따로 추가하고 삭제할 수 있다.")
+    public void addTagTest() {
+        // given : testUser의 레시피와 tagDto를 생성한다.
+        Recipe testRecipe = getSavedTestRecipe();
+        TagDto tagDto = TagDto.builder().tagName(TagName.BOIL).build();
+
+        // when : 생성한 레시피에 태그를 붙인다.
+        TagDto saved = tagService.addTag(tagDto, testRecipe.getId(), testEmail);
+
+        // then : 태그의 추가와 삭제가 가능하다.
+        assertNotNull(tagRepository.findById(saved.getTagId()));
+        assertDoesNotThrow(() -> tagService.deleteTag(saved.getTagId(),testEmail));
+    }
+
+    @Test
+    @DisplayName("레시피 태그를 추가할 수 있는 사람은 레시피 작성자이다.")
+    public void tagAuthorAddTest() {
+        // given1 : testUser의 레시피를 생성한다.
+        Recipe testRecipe = getSavedTestRecipe();
+
+        // given2 : 레시피 작성자가 아닌 anotherUser가 tagDto를 생성된 레시피에 추가하려고 한다.
+        User anotherUser = userRepository.save(User.builder()
+                .name("another").email("another@test.com").role(Role.USER).build());
+        TagDto tagDto = TagDto.builder().tagName(TagName.BOIL).build();
+
+        // when, then : NotOwnerException이 발생한다.
+        assertThrows(NotOwnerException.class, () ->
+                tagService.addTag(tagDto, testRecipe.getId(), anotherUser.getEmail()));
+    }
+
+    @Test
+    @DisplayName("레시피 태그를 삭제할 수 있는 사람은 레시피 작성자이다.")
+    public void tagAuthorDeleteTest() {
+        // given1 : testUser의 레시피에 태그를 더한다.
+        Recipe testRecipe = getSavedTestRecipe();
+        TagDto saved = tagService.addTag(TagDto.builder().tagName(TagName.BOIL).build(),
+                testRecipe.getId(),testEmail);
+
+        // given2 : 레시피 작성자가 아닌 anotherUser
+        User anotherUser = userRepository.save(User.builder()
+                .name("another").email("another@test.com").role(Role.USER).build());
+
+        // when, then : anotherUser가 생성된 태그를 삭제하려고 하면 NotOwnerException이 발생한다.
+        assertThrows(NotOwnerException.class, () ->
+                tagService.deleteTag(saved.getTagId(), anotherUser.getEmail()));
+    }
+
+    @Test
+    @DisplayName("레시피에 달린 태그로 레시피 검색이 가능하다.")
+    public void tagSearchTest() {
+        // given : recipe1, recipe2는 BREAD 태그를,
+        //         recipe3는 CANDY 태그를 갖는다.
+        Recipe recipe1 = getSavedTestRecipe();
+        Recipe recipe2 = getSavedTestRecipe();
+        Recipe recipe3 = getSavedTestRecipe();
+        tagService.addTag(TagDto.builder().tagName(TagName.BREAD).build(),
+                recipe1.getId(), testEmail);
+        tagService.addTag(TagDto.builder().tagName(TagName.BREAD).build(),
+                recipe2.getId(), testEmail);
+        tagService.addTag(TagDto.builder().tagName(TagName.CANDY).build(),
+                recipe3.getId(), testEmail);
+
+        // when : BREAD 태그로 Recipe 조회 요청을 한다.
+        List<Recipe> found = tagService.getRecipeByTag(TagName.BREAD);
+
+        // then : recipe1, recipe2만이 쿼리 결과에 존재한다.
+        assertAll(() -> assertTrue(found.contains(recipe1)),
+                () -> assertTrue(found.contains(recipe2)),
+                () -> assertFalse(found.contains(recipe3)));
+    }
+
+    @Test
+    @DisplayName("같은 태그를 여러 번 추가해도 한 번만 반영된다.")
+    public void idempotentTagTest() {
+        // given : testRecipe를 생성한다.
+        Recipe testRecipe = getSavedTestRecipe();
+
+        // when : 생성된 testRecipe에 동일한 태그를 5번 추가한다.
+        for (int i=0; i<5; i++) {
+            tagService.addTag(TagDto.builder().tagName(TagName.DRINK).build(),
+                    testRecipe.getId(), testEmail);
+        }
+
+        // then : testRecipe에 추가된 태그는 1개이다.
+        assertEquals(1, tagRepository.findByRecipe(testRecipe).size());
+    }
+
+    private Recipe getSavedTestRecipe() {
+        Recipe recipe = Recipe.builder()
+                .title("test").author(testUser)
+                .steps(new ArrayList<>()).tags(new ArrayList<>())
+                .build();
+
+        return recipeService.createRecipe(
+                recipe, new ArrayList<>(), testEmail);
+    }
+}


### PR DESCRIPTION
## 개요
- 레시피에 추가할 태그 기능을 구현했습니다.
- 한 레시피에 여러 개의 태그가 존재할 수 있으며, 태그를 통해 레시피를 검색할 수 있습니다.

## 작업사항
- 실제 postman을 통해 요청을 날리거나, auth 이외의 사항에 대한 컨트롤러 테스트를 위해 security 빈을 profile별로 나눴습니다. (그래봤자 local / prod 두 개가 전부이지만.. 곧 test용도 추가하지 않을까 싶어요.)
- 슬랙에 간단하게 공유드렸던 사항과 같이, 표와 같은 One To Many 구조입니다.![image](https://github.com/f-lab-edu/recipetory/assets/69233405/1aaeae39-1493-4c38-840a-b1300946b1a8)
- `TagName` enum 클래스에 현재 사용할 레시피 태그가 존재합니다. 원래 카테고리로 분류하려고 생각했던만큼 개수가 많지 않아서 이렇게 구성했어요.
- 기존 `RecipeServiceTest`에 tag관련 사항을 추가했습니다.


## 비고?
- 아직 `Recipe` 관련해선 create 기능밖에 만들지 않아서 특정 단건 태그에 대한 레시피 조회만 만들어놓은 상황인데, (`@GetMapping("/tags")`의 컨트롤러 메소드, controller 코드의 `getRecipeByTag()` 등) 레시피 조회 기능 만들 때 다수 태그를 포함한 여러 조건을 통한 검색을 어떻게 만들어볼건지 더 생각해보려고 합니당.. << 막 쿠팡 돌아다니고 한 것도 검색 구현에 참고하려고 그랬던 것 ..
