### PR TITLE
알림 기능 추가

### DIFF
--- a/src/main/java/com/recipetory/notification/application/NotificationService.java
+++ b/src/main/java/com/recipetory/notification/application/NotificationService.java
@@ -62,7 +62,7 @@ public class NotificationService {
     }
 
     /**
-     * id로 조회된 알림을 읽음처리한다.
+     * id로 조회된 알림을 삭제한다.
      * @param notificationId
      * @param logInEmail
      */

--- a/src/main/java/com/recipetory/notification/application/NotificationService.java
+++ b/src/main/java/com/recipetory/notification/application/NotificationService.java
@@ -1,0 +1,108 @@
+package com.recipetory.notification.application;
+
+import com.recipetory.notification.domain.Notification;
+import com.recipetory.notification.domain.NotificationRepository;
+import com.recipetory.notification.presentation.dto.NotificationListDto;
+import com.recipetory.user.application.UserService;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.exception.NotOwnerException;
+import com.recipetory.utils.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+    private final UserService userService;
+
+    /**
+     * 현재 로그인한 유저의 알림을 조회한다.
+     * @param logInEmail
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public NotificationListDto getNotificationsByReceiverEmail(String logInEmail) {
+        User user = userService.getUserByEmail(logInEmail);
+        List<Notification> notifications = notificationRepository.findByReceiver(user);
+
+        return NotificationListDto.fromEntityList(notifications);
+    }
+
+    /**
+     * id로 조회된 알림을 읽음처리한다.
+     * @param notificationId
+     * @param logInEmail
+     */
+    @Transactional
+    public void checkNotification(Long notificationId, String logInEmail) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Notification", String.valueOf(notificationId)));
+        User user = userService.getUserByEmail(logInEmail);
+
+        validateNotificationOwner(notification, user);
+
+        notification.checkNotification();
+    }
+
+    /**
+     * 특정 email을 가진 유저의 알림 전체를 읽음처리한다.
+     * @param logInEmail
+     */
+    @Transactional
+    public void checkAllNotificationByEmail(String logInEmail) {
+        User user = userService.getUserByEmail(logInEmail);
+
+        notificationRepository.findByReceiver(user)
+                .forEach(Notification::checkNotification);
+    }
+
+    /**
+     * id로 조회된 알림을 읽음처리한다.
+     * @param notificationId
+     * @param logInEmail
+     */
+    @Transactional
+    public void deleteNotification(Long notificationId, String logInEmail) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Notification", String.valueOf(notificationId)));
+        User user = userService.getUserByEmail(logInEmail);
+
+        validateNotificationOwner(notification, user);
+
+        notificationRepository.deleteById(notificationId);
+    }
+
+    /**
+     * 특정 email을 가진 유저의 알림 전체를 삭제한다.
+     * @param logInEmail
+     */
+    @Transactional
+    public void deleteAllNotificationByEmail(String logInEmail) {
+        User user = userService.getUserByEmail(logInEmail);
+
+        notificationRepository.deleteAllByReceiver(user);
+    }
+
+    /**
+     * User가 Notifacation의 주인인지 확인한다.
+     * @param notification
+     * @param receiver
+     */
+    @Transactional(readOnly = true)
+    public void validateNotificationOwner(
+            Notification notification, User receiver) {
+
+        if (notification.getReceiver() != receiver) {
+            throw new NotOwnerException(receiver.getId(),
+                    notification.getReceiver().getId(),
+                    "Notification",
+                    notification.getId().toString());
+        }
+    }
+}

--- a/src/main/java/com/recipetory/notification/application/RecipetoryEventListener.java
+++ b/src/main/java/com/recipetory/notification/application/RecipetoryEventListener.java
@@ -1,0 +1,117 @@
+package com.recipetory.notification.application;
+
+import com.recipetory.notification.domain.Notification;
+import com.recipetory.notification.domain.NotificationRepository;
+import com.recipetory.notification.domain.NotificationType;
+import com.recipetory.notification.domain.event.CommentEvent;
+import com.recipetory.notification.domain.event.CreateRecipeEvent;
+import com.recipetory.notification.domain.event.FollowEvent;
+import com.recipetory.notification.domain.event.ReviewEvent;
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.reply.domain.comment.Comment;
+import com.recipetory.reply.domain.review.Review;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.follow.Follow;
+import com.recipetory.user.domain.follow.FollowRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RecipetoryEventListener {
+    private final NotificationRepository notificationRepository;
+    private final FollowRepository followRepository;
+
+    /**
+     * 팔로워들에게 레시피 작성을 알린다.
+     * @param createRecipeEvent
+     */
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleCreateRecipeEvent(CreateRecipeEvent createRecipeEvent) {
+        Recipe createdRecipe = createRecipeEvent.getRecipe();
+        User author = createdRecipe.getAuthor();
+
+        log.info("{} creates recipe {}", author.getId(), createdRecipe.getId());
+
+        followRepository.findByFollowed(author)
+                .forEach(follow -> {
+                    User follower = follow.getFollowing();
+
+                    notificationRepository.save(Notification.builder()
+                            .sender(author).receiver(follower)
+                            .notificationType(NotificationType.NEW_RECIPE)
+                            .message(NotificationType.NEW_RECIPE.getDefaultMessage(author))
+                            .path("/recipes/" + createdRecipe.getId())
+                            .build());
+                });
+    }
+
+    /**
+     * 팔로우 알림
+     * @param followEvent
+     */
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleFollowEvent(FollowEvent followEvent) {
+        Follow follow = followEvent.getFollow();
+        User sender = follow.getFollowing();
+        User receiver = follow.getFollowed();
+
+        log.info("{} follows {}", sender.getId(), receiver.getId());
+
+        notificationRepository.save(Notification.builder()
+                .notificationType(NotificationType.FOLLOW)
+                .sender(sender).receiver(receiver)
+                .message(NotificationType.FOLLOW.getDefaultMessage(sender))
+                .path("/"+sender.getId())
+                .build());
+    }
+
+    /**
+     * 댓글 알림
+     * @param commentEvent
+     */
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleCommentEvent(CommentEvent commentEvent) {
+        Comment comment = commentEvent.getComment();
+        User sender = comment.getAuthor();
+        User receiver = comment.getRecipe().getAuthor();
+
+        log.info("{} comments {}", sender.getId(), comment.getId());
+
+        notificationRepository.save(Notification.builder()
+                .sender(sender).receiver(receiver)
+                .notificationType(NotificationType.COMMENT)
+                .message(NotificationType.COMMENT.getDefaultMessage(sender))
+                .path("/comment/" + comment.getId())
+                .build());
+    }
+
+    /**
+     * 리뷰 알림
+     * @param reviewEvent
+     */
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleCommentEvent(ReviewEvent reviewEvent) {
+        Review review = reviewEvent.getReview();
+        User sender = review.getAuthor();
+        User receiver = review.getRecipe().getAuthor();
+
+        log.info("{} reviewed {}", sender.getId(), review.getId());
+
+        notificationRepository.save(Notification.builder()
+                .sender(sender).receiver(receiver)
+                .notificationType(NotificationType.REVIEW)
+                .message(NotificationType.REVIEW.getDefaultMessage(sender))
+                .path("/review/" + review.getId())
+                .build());
+    }
+}

--- a/src/main/java/com/recipetory/notification/application/RecipetoryEventListener.java
+++ b/src/main/java/com/recipetory/notification/application/RecipetoryEventListener.java
@@ -3,10 +3,10 @@ package com.recipetory.notification.application;
 import com.recipetory.notification.domain.Notification;
 import com.recipetory.notification.domain.NotificationRepository;
 import com.recipetory.notification.domain.NotificationType;
-import com.recipetory.notification.domain.event.CommentEvent;
+import com.recipetory.notification.domain.event.CreateCommentEvent;
 import com.recipetory.notification.domain.event.CreateRecipeEvent;
 import com.recipetory.notification.domain.event.FollowEvent;
-import com.recipetory.notification.domain.event.ReviewEvent;
+import com.recipetory.notification.domain.event.CreateReviewEvent;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.reply.domain.comment.Comment;
 import com.recipetory.reply.domain.review.Review;
@@ -75,12 +75,12 @@ public class RecipetoryEventListener {
 
     /**
      * 댓글 알림
-     * @param commentEvent
+     * @param createCommentEvent
      */
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleCommentEvent(CommentEvent commentEvent) {
-        Comment comment = commentEvent.getComment();
+    public void handleCommentEvent(CreateCommentEvent createCommentEvent) {
+        Comment comment = createCommentEvent.getComment();
         User sender = comment.getAuthor();
         User receiver = comment.getRecipe().getAuthor();
 
@@ -96,12 +96,12 @@ public class RecipetoryEventListener {
 
     /**
      * 리뷰 알림
-     * @param reviewEvent
+     * @param createReviewEvent
      */
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleCommentEvent(ReviewEvent reviewEvent) {
-        Review review = reviewEvent.getReview();
+    public void handleCommentEvent(CreateReviewEvent createReviewEvent) {
+        Review review = createReviewEvent.getReview();
         User sender = review.getAuthor();
         User receiver = review.getRecipe().getAuthor();
 

--- a/src/main/java/com/recipetory/notification/domain/Notification.java
+++ b/src/main/java/com/recipetory/notification/domain/Notification.java
@@ -1,0 +1,49 @@
+package com.recipetory.notification.domain;
+
+import com.recipetory.user.domain.User;
+import com.recipetory.utils.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class Notification extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private boolean isRead;
+
+    @Column(length = 200)
+    private String message;
+
+    // notification 관련된 정보 링크
+    @Column
+    private String path;
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @JoinColumn(name = "receiver_id",
+            updatable = false)
+    @ManyToOne(targetEntity = User.class,
+            fetch = FetchType.LAZY)
+    private User receiver;
+
+    @JoinColumn(name = "sender_id")
+    @ManyToOne(targetEntity = User.class,
+            fetch = FetchType.LAZY)
+    private User sender;
+
+    public void checkNotification() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/com/recipetory/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/recipetory/notification/domain/NotificationRepository.java
@@ -1,0 +1,18 @@
+package com.recipetory.notification.domain;
+
+import com.recipetory.user.domain.User;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository {
+    Notification save(Notification notification);
+
+    Optional<Notification> findById(Long id);
+
+    List<Notification> findByReceiver(User receiver);
+
+    void deleteById(Long notificationId);
+
+    void deleteAllByReceiver(User receiver);
+}

--- a/src/main/java/com/recipetory/notification/domain/NotificationType.java
+++ b/src/main/java/com/recipetory/notification/domain/NotificationType.java
@@ -1,0 +1,23 @@
+package com.recipetory.notification.domain;
+
+import com.recipetory.user.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.function.Function;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    NEW_RECIPE((sender) -> sender + "님이 새 레시피를 작성하셨습니다."),
+    FOLLOW((sender) -> sender + "님이 나를 팔로우합니다."),
+    COMMENT((sender) -> sender + "님이 나의 레시피에 댓글을 달았습니다."),
+    REVIEW((sender) -> sender + "님이 나의 레시피에 리뷰를 달았습니다."),
+    ETC((sender) -> sender + "님으로부터의 알림");
+
+    private final Function<String, String> defaultMessage;
+
+    public String getDefaultMessage(User sender) {
+        return defaultMessage.apply(sender.getName());
+    }
+}

--- a/src/main/java/com/recipetory/notification/domain/event/CommentEvent.java
+++ b/src/main/java/com/recipetory/notification/domain/event/CommentEvent.java
@@ -1,0 +1,11 @@
+package com.recipetory.notification.domain.event;
+
+import com.recipetory.reply.domain.comment.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentEvent {
+    private final Comment comment;
+}

--- a/src/main/java/com/recipetory/notification/domain/event/CreateCommentEvent.java
+++ b/src/main/java/com/recipetory/notification/domain/event/CreateCommentEvent.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class CommentEvent {
+public class CreateCommentEvent {
     private final Comment comment;
 }

--- a/src/main/java/com/recipetory/notification/domain/event/CreateRecipeEvent.java
+++ b/src/main/java/com/recipetory/notification/domain/event/CreateRecipeEvent.java
@@ -1,0 +1,11 @@
+package com.recipetory.notification.domain.event;
+
+import com.recipetory.recipe.domain.Recipe;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateRecipeEvent {
+    private final Recipe recipe;
+}

--- a/src/main/java/com/recipetory/notification/domain/event/CreateReviewEvent.java
+++ b/src/main/java/com/recipetory/notification/domain/event/CreateReviewEvent.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ReviewEvent {
+public class CreateReviewEvent {
     private final Review review;
 }

--- a/src/main/java/com/recipetory/notification/domain/event/FollowEvent.java
+++ b/src/main/java/com/recipetory/notification/domain/event/FollowEvent.java
@@ -1,0 +1,11 @@
+package com.recipetory.notification.domain.event;
+
+import com.recipetory.user.domain.follow.Follow;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FollowEvent {
+    private final Follow follow;
+}

--- a/src/main/java/com/recipetory/notification/domain/event/ReviewEvent.java
+++ b/src/main/java/com/recipetory/notification/domain/event/ReviewEvent.java
@@ -1,0 +1,11 @@
+package com.recipetory.notification.domain.event;
+
+import com.recipetory.reply.domain.review.Review;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReviewEvent {
+    private final Review review;
+}

--- a/src/main/java/com/recipetory/notification/infrastructure/NotificationJpaRepository.java
+++ b/src/main/java/com/recipetory/notification/infrastructure/NotificationJpaRepository.java
@@ -1,0 +1,13 @@
+package com.recipetory.notification.infrastructure;
+
+import com.recipetory.notification.domain.Notification;
+import com.recipetory.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByReceiver(User receiver);
+
+    void deleteAllByReceiver(User receiver);
+}

--- a/src/main/java/com/recipetory/notification/infrastructure/NotificationRepositoryImpl.java
+++ b/src/main/java/com/recipetory/notification/infrastructure/NotificationRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.recipetory.notification.infrastructure;
+
+import com.recipetory.notification.domain.Notification;
+import com.recipetory.notification.domain.NotificationRepository;
+import com.recipetory.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepository {
+    private final NotificationJpaRepository notificationJpaRepository;
+
+    @Override
+    public Notification save(Notification notification) {
+        return notificationJpaRepository.save(notification);
+    }
+
+    @Override
+    public Optional<Notification> findById(Long id) {
+        return notificationJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Notification> findByReceiver(User receiver) {
+        return notificationJpaRepository.findByReceiver(receiver);
+    }
+
+    @Override
+    public void deleteById(Long notificationId) {
+        notificationJpaRepository.deleteById(notificationId);
+    }
+
+    @Override
+    public void deleteAllByReceiver(User receiver) {
+        notificationJpaRepository.deleteAllByReceiver(receiver);
+    }
+}

--- a/src/main/java/com/recipetory/notification/presentation/NotificationController.java
+++ b/src/main/java/com/recipetory/notification/presentation/NotificationController.java
@@ -1,0 +1,80 @@
+package com.recipetory.notification.presentation;
+
+import com.recipetory.config.auth.argumentresolver.LogInUser;
+import com.recipetory.config.auth.dto.SessionUser;
+import com.recipetory.notification.application.NotificationService;
+import com.recipetory.notification.presentation.dto.NotificationListDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    /**
+     * 현재 로그인한 유저의 알림 목록을 조회한다.
+     * @param logInUser
+     * @return 알림 목록
+     */
+    @GetMapping("/notifications")
+    public ResponseEntity<NotificationListDto> getNotifications(
+            @LogInUser SessionUser logInUser) {
+        NotificationListDto notificationListDto =
+                notificationService.getNotificationsByReceiverEmail(logInUser.getEmail());
+
+        return ResponseEntity.ok(notificationListDto);
+    }
+
+    /**
+     * notificationId에 맞는 알림을 읽음처리한다.
+     * @param notificationId
+     * @param logInUser
+     * @return
+     */
+    @PutMapping("/notifications/{notificationId}")
+    public ResponseEntity<Void> checkNotification(
+            @PathVariable Long notificationId,
+            @LogInUser SessionUser logInUser) {
+        notificationService.checkNotification(notificationId, logInUser.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 현재 로그인한 유저의 알림을 모두 읽음처리한다.
+     * @param logInUser
+     * @return
+     */
+    @PutMapping("/notifications")
+    public ResponseEntity<Void> checkAllNotification(
+            @LogInUser SessionUser logInUser) {
+        notificationService.checkAllNotificationByEmail(logInUser.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * notificationId에 맞는 알림을 삭제한다.
+     * @param notificationId
+     * @return
+     */
+    @DeleteMapping("/notifications/{notificationId}")
+    public ResponseEntity<Void> deleteNotification(
+            @PathVariable Long notificationId,
+            @LogInUser SessionUser logInUser) {
+        notificationService.deleteNotification(notificationId, logInUser.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 현재 로그인한 유저의 알림 전체를 삭제한다.
+     * @param logInUser
+     * @return
+     */
+    @DeleteMapping("/notifications")
+    public ResponseEntity<Void> deleteAllNotification(
+            @LogInUser SessionUser logInUser) {
+        notificationService.deleteAllNotificationByEmail(logInUser.getEmail());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/recipetory/notification/presentation/dto/NotificationDto.java
+++ b/src/main/java/com/recipetory/notification/presentation/dto/NotificationDto.java
@@ -1,0 +1,31 @@
+package com.recipetory.notification.presentation.dto;
+
+import com.recipetory.notification.domain.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class NotificationDto {
+    private Long id;
+    private String path;
+    private String message;
+    private boolean isRead;
+    private LocalDateTime createdAt;
+
+    public static NotificationDto fromEntity(Notification notification) {
+        return NotificationDto.builder()
+                .id(notification.getId())
+                .path(notification.getPath())
+                .message(notification.getMessage())
+                .isRead(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/recipetory/notification/presentation/dto/NotificationListDto.java
+++ b/src/main/java/com/recipetory/notification/presentation/dto/NotificationListDto.java
@@ -1,0 +1,25 @@
+package com.recipetory.notification.presentation.dto;
+
+import com.recipetory.notification.domain.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class NotificationListDto {
+    private List<NotificationDto> notifications;
+
+    public static NotificationListDto fromEntityList(
+            List<Notification> notifications
+    ) {
+        return new NotificationListDto(
+                notifications.stream()
+                        .map(NotificationDto::fromEntity).toList());
+    }
+}

--- a/src/main/java/com/recipetory/reply/application/CommentService.java
+++ b/src/main/java/com/recipetory/reply/application/CommentService.java
@@ -1,6 +1,6 @@
 package com.recipetory.reply.application;
 
-import com.recipetory.notification.domain.event.CommentEvent;
+import com.recipetory.notification.domain.event.CreateCommentEvent;
 import com.recipetory.recipe.application.RecipeService;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.reply.domain.comment.Comment;
@@ -42,7 +42,7 @@ public class CommentService {
                 commentDto.toEntity(author,recipe));
         updateCommentCount(recipe);
 
-        eventPublisher.publishEvent(new CommentEvent(created));
+        eventPublisher.publishEvent(new CreateCommentEvent(created));
 
         return created;
     }

--- a/src/main/java/com/recipetory/reply/application/CommentService.java
+++ b/src/main/java/com/recipetory/reply/application/CommentService.java
@@ -1,5 +1,6 @@
 package com.recipetory.reply.application;
 
+import com.recipetory.notification.domain.event.CommentEvent;
 import com.recipetory.recipe.application.RecipeService;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.reply.domain.comment.Comment;
@@ -10,6 +11,7 @@ import com.recipetory.user.application.UserService;
 import com.recipetory.user.domain.User;
 import com.recipetory.utils.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final RecipeService recipeService;
     private final UserService userService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 레시피에 대한 댓글을 추가한다.
@@ -38,6 +41,8 @@ public class CommentService {
         Comment created = commentRepository.save(
                 commentDto.toEntity(author,recipe));
         updateCommentCount(recipe);
+
+        eventPublisher.publishEvent(new CommentEvent(created));
 
         return created;
     }

--- a/src/main/java/com/recipetory/reply/application/ReviewService.java
+++ b/src/main/java/com/recipetory/reply/application/ReviewService.java
@@ -1,5 +1,6 @@
 package com.recipetory.reply.application;
 
+import com.recipetory.notification.domain.event.ReviewEvent;
 import com.recipetory.recipe.application.RecipeService;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.reply.domain.exception.CannotReviewException;
@@ -11,6 +12,7 @@ import com.recipetory.user.application.UserService;
 import com.recipetory.user.domain.User;
 import com.recipetory.utils.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final RecipeService recipeService;
     private final UserService userService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 레시피에 대한 리뷰를 추가한다.
@@ -42,6 +45,8 @@ public class ReviewService {
         Review created = reviewRepository.save(
                 reviewDto.toEntity(author,recipe));
         updateReviewStatistic(recipe);
+
+        eventPublisher.publishEvent(new ReviewEvent(created));
 
         return created;
     }

--- a/src/main/java/com/recipetory/reply/application/ReviewService.java
+++ b/src/main/java/com/recipetory/reply/application/ReviewService.java
@@ -1,6 +1,6 @@
 package com.recipetory.reply.application;
 
-import com.recipetory.notification.domain.event.ReviewEvent;
+import com.recipetory.notification.domain.event.CreateReviewEvent;
 import com.recipetory.recipe.application.RecipeService;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.reply.domain.exception.CannotReviewException;
@@ -46,7 +46,7 @@ public class ReviewService {
                 reviewDto.toEntity(author,recipe));
         updateReviewStatistic(recipe);
 
-        eventPublisher.publishEvent(new ReviewEvent(created));
+        eventPublisher.publishEvent(new CreateReviewEvent(created));
 
         return created;
     }

--- a/src/main/java/com/recipetory/tag/presentation/dto/TagDto.java
+++ b/src/main/java/com/recipetory/tag/presentation/dto/TagDto.java
@@ -21,7 +21,6 @@ public class TagDto {
     private TagName tagName;
 
     public Tag toEntity() {
-        System.out.println(tagName);
         return Tag.builder()
                 .tagName(tagName)
                 .build();

--- a/src/main/java/com/recipetory/user/domain/follow/Follow.java
+++ b/src/main/java/com/recipetory/user/domain/follow/Follow.java
@@ -3,12 +3,16 @@ package com.recipetory.user.domain.follow;
 import com.recipetory.user.domain.User;
 import com.recipetory.utils.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Builder
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Follow extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/recipetory/notification/application/NotificationServiceUnitTest.java
+++ b/src/test/java/com/recipetory/notification/application/NotificationServiceUnitTest.java
@@ -1,0 +1,120 @@
+package com.recipetory.notification.application;
+
+import com.recipetory.notification.domain.Notification;
+import com.recipetory.notification.domain.NotificationRepository;
+import com.recipetory.notification.domain.NotificationType;
+import com.recipetory.notification.presentation.dto.NotificationDto;
+import com.recipetory.user.application.UserService;
+import com.recipetory.user.domain.Role;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.exception.NotOwnerException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceUnitTest {
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    User receiver;
+    Notification notification1, notification2;
+    List<Notification> notifications = new ArrayList<>();
+
+    @BeforeEach
+    public void setUp() {
+        receiver = User.builder().id(1L).name("receiver").email("receiver@test.com").role(Role.USER).build();
+
+        notification1 = Notification.builder()
+                .id(1L).notificationType(NotificationType.NEW_RECIPE)
+                .receiver(receiver).build();
+        notification2 = Notification.builder()
+                .id(2L).notificationType(NotificationType.ETC)
+                .receiver(receiver).build();
+        notifications.addAll(Arrays.asList(notification1, notification2));
+    }
+
+    @Test
+    @DisplayName("유저의 이메일로 알림이 조회된다.")
+    public void testGetNotification() {
+        // given : receiver 유저가 receiver인 알림 2개가 생성된다.(setUp)
+        when(userService.getUserByEmail(receiver.getEmail())).thenReturn(receiver);
+        when(notificationRepository.findByReceiver(receiver)).thenReturn(notifications);
+
+        // when : receiver email로 조회한다.
+        List<NotificationDto> notificationDtos =
+                notificationService.getNotificationsByReceiverEmail(
+                        receiver.getEmail()).getNotifications();
+
+        // then : 조회된 알림과 생성된 알림의 개수가 같다.
+        assertEquals(2, notificationDtos.size());
+
+    }
+
+    @Test
+    @DisplayName("notification id로 알림 읽음 처리가 가능하다.")
+    public void checkNotificationTest() {
+        // given : receiver가 receiver, notification id가 1L인 알림이 생성된다.
+        Long notificationId = 1L;
+        when(userService.getUserByEmail(receiver.getEmail())).thenReturn(receiver);
+        when(notificationRepository.findById(notification1.getId())).thenReturn(Optional.ofNullable(notification1));
+
+        // when : id를 통해 알림을 check하는 메소드를 수행한다.
+        notificationService.checkNotification(notificationId, receiver.getEmail());
+
+        // then : 알람의 읽음 상태(isRead)는 true이다.
+        notificationRepository.findById(notificationId)
+                .ifPresent(notification -> {
+                    assertTrue(notification.isRead());
+                });
+    }
+
+    @Test
+    @DisplayName("특정 유저의 모든 알림을 읽음 처리하는 것이 가능하다.")
+    public void checkAllTest() {
+        // given : receiver 유저가 receiver인 알림 2개가 생성된다.(setUp)
+        when(userService.getUserByEmail(receiver.getEmail())).thenReturn(receiver);
+        when(notificationRepository.findByReceiver(receiver)).thenReturn(notifications);
+
+        // when : receiver 유저의 알림 전체를 읽음처리 한다.
+        notificationService.checkAllNotificationByEmail(receiver.getEmail());
+
+        // then : 알림 전체의 읽음상태(isRead)는 true이다.
+        notificationRepository.findByReceiver(receiver).forEach(notification -> {
+            assertTrue(notification.isRead());
+        });
+    }
+
+    @Test
+    @DisplayName("알림의 주인이 아닌 유저가 알림을 삭제하려고 하면 예외가 발생한다.")
+    public void notificationOwnerTest() {
+        // given : receiver가 receiver, notification id가 1L인 알림이 생성된다.
+        Long notificationId = 1L;
+        when(notificationRepository.findById(notification1.getId())).thenReturn(Optional.ofNullable(notification1));
+
+        // given2 : 알람의 주인이 아닌 another 유저가 존재한다.
+        User another = User.builder().id(2L).name("another").email("another@test.com").role(Role.USER).build();
+        when(userService.getUserByEmail(another.getEmail())).thenReturn(another);
+
+        // when, then : another 유저가 알람을 삭제하려고 하면, NotOwnerException이 발생한다.
+        assertThrows(NotOwnerException.class,() ->
+                notificationService.deleteNotification(notificationId,another.getEmail()));
+    }
+}

--- a/src/test/java/com/recipetory/notification/application/NotificationTest.java
+++ b/src/test/java/com/recipetory/notification/application/NotificationTest.java
@@ -1,0 +1,169 @@
+package com.recipetory.notification.application;
+
+import com.recipetory.notification.domain.Notification;
+import com.recipetory.notification.domain.NotificationRepository;
+import com.recipetory.notification.domain.NotificationType;
+import com.recipetory.recipe.application.RecipeService;
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.recipe.domain.RecipeInfo;
+import com.recipetory.recipe.domain.RecipeStatistics;
+import com.recipetory.reply.application.CommentService;
+import com.recipetory.reply.application.ReviewService;
+import com.recipetory.reply.presentation.comment.dto.CreateCommentDto;
+import com.recipetory.reply.presentation.review.dto.CreateReviewDto;
+import com.recipetory.user.application.FollowService;
+import com.recipetory.user.domain.Role;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+// @DirtiesContext : spring boot test에서 application context를 재사용하는 것을 막아줌
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class NotificationTest {
+    @Autowired
+    private FollowService followService;
+    @Autowired
+    private RecipeService recipeService;
+    @Autowired
+    private CommentService commentService;
+    @Autowired
+    private ReviewService reviewService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Test
+    @DisplayName("레시피를 작성하면 팔로워들에게 알림이 생성된다.")
+    public void createdRecipeNotificationTest() {
+        // given : author 유저를 follower가 팔로우한다.
+        User author = userRepository.save(User.builder()
+                .name("author").email("author@test.com").role(Role.USER).build());
+        User follower = userRepository.save(User.builder()
+                .name("follower1").email("follower1@test.com").role(Role.USER).build());
+        followService.follow(follower.getEmail(),author.getId());
+
+        // when : author 유저가 새로운 레시피를 작성한다.
+        Recipe recipe = Recipe.builder()
+                .title("test").recipeInfo(new RecipeInfo()).recipeStatistics(new RecipeStatistics())
+                .steps(new ArrayList<>()).tags(new ArrayList<>()).ingredients(new ArrayList<>())
+                .build();
+        recipeService.createRecipe(recipe,new ArrayList<>(),author.getEmail());
+
+        // TransactionalEventListener 사용중이기 때문에, 이전 transaction commit 필요
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        // then : sender가 author, receiver가 follower인 NEW_RECIPE 알림이 1개 생성된다.
+        List<Notification> notifications = notificationRepository.findByReceiver(follower);
+        assertEquals(1,notifications.size());
+
+        Notification notification = notifications.get(0);
+        assertEquals(author.getId(),notification.getSender().getId()); // sender
+        assertEquals(NotificationType.NEW_RECIPE, notification.getNotificationType()); // NEW_RECIPE
+    }
+
+    @Test
+    @DisplayName("팔로우를 하면 팔로우 당한 사람에게 알림이 생성된다.")
+    public void followNotificationTest() {
+        // given : 팔로우 당하는 followed, 팔로우 하는 follower 유저가 존재한다.
+        User followed = userRepository.save(User.builder()
+                .name("author").email("author@test.com").role(Role.USER).build());
+        User follower = userRepository.save(User.builder()
+                .name("follower1").email("follower1@test.com").role(Role.USER).build());
+
+        // when : follower 유저가 follow 유저를 팔로우한다.
+        followService.follow(follower.getEmail(),followed.getId());
+
+        // TransactionalEventListener를 사용중이기 때문에, 이전 transaction commit 필요
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        // then : sender가 follower, receiver가 followed인 FOLLOW 알림이 1개 생성된다.
+        List<Notification> notifications = notificationRepository.findByReceiver(followed);
+        assertEquals(1,notifications.size());
+
+        Notification notification = notifications.get(0);
+        assertEquals(follower.getId(), notification.getSender().getId()); // sender
+        assertEquals(NotificationType.FOLLOW, notification.getNotificationType()); // FOLLOW
+    }
+
+    @Test
+    @DisplayName("레시피 작성자에게 댓글 작성 알림이 생성된다.")
+    public void commentNotificationTest() {
+        // given : recipeAuthor 유저가 recipe 레시피를 생성한다.
+        User recipeAuthor = userRepository.save(User.builder()
+                .name("recipeAuthor").email("recipeAutho@test.com").role(Role.USER).build());
+        Recipe recipe = Recipe.builder()
+                .title("test").recipeInfo(new RecipeInfo()).recipeStatistics(new RecipeStatistics())
+                .steps(new ArrayList<>()).tags(new ArrayList<>()).ingredients(new ArrayList<>())
+                .build();
+        recipeService.createRecipe(recipe,new ArrayList<>(),recipeAuthor.getEmail());
+
+        // when : commentAuthor 유저가 댓글을 생성한다.
+        User commentAuthor = userRepository.save(User.builder()
+                .name("commentAuthor").email("commentAuthor@test.com").role(Role.USER).build());
+        commentService.createComment(commentAuthor.getEmail(), new CreateCommentDto(
+                recipe.getId(),"test comment"));
+
+        // TransactionalEventListener 사용중이기 때문에, 이전 transaction commit 필요
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        // then : sender가 commentAuthor, receiver가 recipeAuthor인 COMMENT 알림이 1개 생성된다.
+        List<Notification> notifications = notificationRepository.findByReceiver(recipeAuthor);
+        assertEquals(1,notifications.size()); // 1개
+
+        Notification notification = notifications.get(0);
+        assertEquals(commentAuthor.getId(), notification.getSender().getId()); // sender
+        assertEquals(NotificationType.COMMENT, notification.getNotificationType()); // COMMENT
+    }
+
+    @Test
+    @DisplayName("레시피 작성자에게 리뷰 작성 알림이 생성된다.")
+    public void reviewNotificationTest() {
+        // given : recipeAuthor 유저가 레시피를 생성한다.
+        User recipeAuthor = userRepository.save(User.builder()
+                .name("recipeAuthor").email("recipeAutho@test.com").role(Role.USER).build());
+        Recipe recipe = Recipe.builder()
+                .title("test").recipeInfo(new RecipeInfo()).recipeStatistics(new RecipeStatistics())
+                .steps(new ArrayList<>()).tags(new ArrayList<>()).ingredients(new ArrayList<>())
+                .build();
+        recipeService.createRecipe(recipe,new ArrayList<>(),recipeAuthor.getEmail());
+
+        // when : reviewAuthor 유저가 리뷰를 생성한다.
+        User reviewAuthor = userRepository.save(User.builder()
+                .name("reviewAuthor").email("reviewAuthor@test.com").role(Role.USER).build());
+        reviewService.createReview(reviewAuthor.getEmail(), new CreateReviewDto(
+                recipe.getId(),30,"test review"));
+
+        // TransactionalEventListener 사용중이기 때문에, 이전 transaction commit 필요
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        // then : sender가 reviewAuthor, receiver가 recipeAuthor인 COMMENT 알림이 1개 생성된다.
+        List<Notification> notifications = notificationRepository.findByReceiver(recipeAuthor);
+        assertEquals(1,notifications.size());
+
+        Notification notification = notifications.get(0);
+        assertEquals(reviewAuthor.getId(), notification.getSender().getId());
+        assertEquals(NotificationType.REVIEW, notification.getNotificationType());
+    }
+}


### PR DESCRIPTION
## 개요
#15 의 알림 기능 추가했습니다.
- 누군가 유저를 팔로우했을 때 팔로우 당한 사람이
- 유저가 레시피를 업로드했을 때 해당 유저를 팔로우(=소식 받기)한 사람들이
- 레시피에 댓글이나 리뷰가 달렸을 때 레시피 주인이

알림을 받을 수 있도록 기능을 구현해보았어욥.

## 작업사항
- `Notification` 엔티티에 `isRead`, `receiver`, `notificationType`, `message` 등 알림에 필요한 기능 필드를 나름대로 생각해서 구성해보았습니당.
- 슬랙에 공유드린 것처럼 `ApplicationEventPublisher`를 이용해 개요에 나와있는 각 상황에 따른 이벤트 객체를 만들고 `publish()` 메소드 + `@EventListener` 조합을 사용해봤어요. 
- "원래 기능이 알람 발송 실패 때문에 함께 실패하지 않도록 구성하는게 중요합니다" 에서, `Notification`과 관련한 로직 실행 도중 예외가 발생했을 때 원래 기능까지 롤백되는걸 막으면서 알림 엔티티를 생성하기 위해 `@TransactionalEventListener` + `@Transactional(propagation = Propagation.REQUIRES_NEW)`를 사용했어요.. [참고](https://ksh-coding.tistory.com/111)
- 테스트가.. event publisher 들어오면서 저의 능력으로 능숙하게 짜기 애매해져서.. (원래는 능숙하게짠줄ㅋ) publisher 기능 자체에 대해선 통합 테스트를, 알림 서비스에 대해선 mock을 사용했습니다.. 그마저도 방금 언급한 event 트랜잭션 설정때문에 짜는데 좀 곤란했습니다 ㅜㅅㅜ

## 비고
- 팔로워가 1000명인 유저 10명이 10번만 글을 올려도 알림이 10만개 !!!
- 이런 기능에 `@Async`를 사용할 수도 있는 것 같다고 하네용?
