### PR TITLE
kafka를 메세지 큐로 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+	implementation 'org.springframework.kafka:spring-kafka'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+	implementation 'org.springframework.boot:spring-boot-testcontainers:3.1.2'
 	testRuntimeOnly 'com.h2database:h2'
 }
 

--- a/src/main/java/com/recipetory/RecipetoryApplication.java
+++ b/src/main/java/com/recipetory/RecipetoryApplication.java
@@ -2,8 +2,10 @@ package com.recipetory;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class RecipetoryApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/recipetory/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,55 @@
+package com.recipetory.config.kafka;
+
+import com.recipetory.notification.presentation.dto.NotificationMessage;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+    @Value("${spring.kafka.group-id}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, NotificationMessage> notificationConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                bootstrapAddress);
+        props.put(
+                ConsumerConfig.GROUP_ID_CONFIG,
+                groupId);
+        props.put(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class);
+        props.put(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                JsonDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(props,
+                new StringDeserializer(),
+                new JsonDeserializer<>(NotificationMessage.class));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, NotificationMessage>
+    notificationKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, NotificationMessage> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(notificationConsumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/recipetory/config/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaProducerConfig.java
@@ -1,0 +1,43 @@
+package com.recipetory.config.kafka;
+
+import com.recipetory.notification.presentation.dto.NotificationMessage;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean
+    public ProducerFactory<String, NotificationMessage> notificationProducerFactory() {
+        Map<String,Object> configProps = new HashMap<>();
+
+        configProps.put(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                bootstrapAddress);
+        configProps.put(
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class);
+        configProps.put(
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, NotificationMessage> notificationKafkaTemplate() {
+        return new KafkaTemplate<>(notificationProducerFactory());
+    }
+}

--- a/src/main/java/com/recipetory/config/kafka/KafkaTopic.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaTopic.java
@@ -2,4 +2,5 @@ package com.recipetory.config.kafka;
 
 public interface KafkaTopic {
     public final String NOTIFICATION = "notification";
+    public final String FOLLOWER_NOTIFICATION = "follower-notification";
 }

--- a/src/main/java/com/recipetory/config/kafka/KafkaTopic.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaTopic.java
@@ -1,0 +1,5 @@
+package com.recipetory.config.kafka;
+
+public interface KafkaTopic {
+    public final String NOTIFICATION = "notification";
+}

--- a/src/main/java/com/recipetory/config/kafka/KafkaTopicConfig.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaTopicConfig.java
@@ -26,4 +26,9 @@ public class KafkaTopicConfig {
     public NewTopic notificationTopic() {
         return new NewTopic(KafkaTopic.NOTIFICATION, 2, (short) 2);
     }
+
+    @Bean
+    public NewTopic followNotificationTopic() {
+        return new NewTopic(KafkaTopic.FOLLOWER_NOTIFICATION, 2, (short) 2);
+    }
 }

--- a/src/main/java/com/recipetory/config/kafka/KafkaTopicConfig.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaTopicConfig.java
@@ -1,0 +1,29 @@
+package com.recipetory.config.kafka;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaAdmin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaTopicConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        return new KafkaAdmin(configs);
+    }
+
+    @Bean
+    public NewTopic notificationTopic() {
+        return new NewTopic(KafkaTopic.NOTIFICATION, 2, (short) 2);
+    }
+}

--- a/src/main/java/com/recipetory/notification/application/RecipetoryEventListener.java
+++ b/src/main/java/com/recipetory/notification/application/RecipetoryEventListener.java
@@ -1,5 +1,6 @@
 package com.recipetory.notification.application;
 
+import com.recipetory.config.kafka.KafkaTopic;
 import com.recipetory.notification.domain.NotificationMessageSender;
 import com.recipetory.notification.domain.NotificationType;
 import com.recipetory.notification.domain.event.CreateCommentEvent;
@@ -12,7 +13,6 @@ import com.recipetory.reply.domain.comment.Comment;
 import com.recipetory.reply.domain.review.Review;
 import com.recipetory.user.domain.User;
 import com.recipetory.user.domain.follow.Follow;
-import com.recipetory.user.domain.follow.FollowRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -37,13 +37,13 @@ public class RecipetoryEventListener {
         // 생성된 레시피, 알림 종류 정보 구성
         Recipe createdRecipe = createRecipeEvent.getRecipe();
         User author = createdRecipe.getAuthor();
-        NotificationType type = NotificationType.NEW_RECIPE;
 
         // logging
         log.info("{} created recipe {}", author.getId(), createdRecipe.getId());
 
         NotificationMessage message = NotificationMessage.builder()
                 .notificationType(NotificationType.NEW_RECIPE)
+                .topic(KafkaTopic.FOLLOWER_NOTIFICATION)
                 .path(NotificationType.NEW_RECIPE.getDefaultPath(author.getId()))
                 .senderId(author.getId()).build();
 
@@ -67,6 +67,7 @@ public class RecipetoryEventListener {
 
         NotificationMessage message = NotificationMessage.builder()
                 .notificationType(NotificationType.FOLLOW)
+                .topic(KafkaTopic.NOTIFICATION)
                 .path(NotificationType.FOLLOW.getDefaultPath(sender.getId()))
                 .senderId(sender.getId()).receiverId(receiver.getId())
                 .build();
@@ -90,6 +91,7 @@ public class RecipetoryEventListener {
         log.info("{} comments {}", sender.getId(), comment.getId());
 
         NotificationMessage message = NotificationMessage.builder()
+                .topic(KafkaTopic.NOTIFICATION)
                 .notificationType(type).path(type.getDefaultPath(comment.getId()))
                 .senderId(sender.getId()).receiverId(receiver.getId())
                 .build();
@@ -113,6 +115,7 @@ public class RecipetoryEventListener {
         log.info("{} reviewed {}", sender.getId(), review.getId());
 
         NotificationMessage message = NotificationMessage.builder()
+                .topic(KafkaTopic.NOTIFICATION)
                 .notificationType(type).path(type.getDefaultPath(review.getId()))
                 .senderId(sender.getId()).receiverId(receiver.getId())
                 .build();

--- a/src/main/java/com/recipetory/notification/application/RecipetoryEventListener.java
+++ b/src/main/java/com/recipetory/notification/application/RecipetoryEventListener.java
@@ -1,12 +1,12 @@
 package com.recipetory.notification.application;
 
-import com.recipetory.notification.domain.Notification;
-import com.recipetory.notification.domain.NotificationRepository;
+import com.recipetory.notification.domain.NotificationMessageSender;
 import com.recipetory.notification.domain.NotificationType;
 import com.recipetory.notification.domain.event.CreateCommentEvent;
 import com.recipetory.notification.domain.event.CreateRecipeEvent;
-import com.recipetory.notification.domain.event.FollowEvent;
 import com.recipetory.notification.domain.event.CreateReviewEvent;
+import com.recipetory.notification.domain.event.FollowEvent;
+import com.recipetory.notification.presentation.dto.NotificationMessage;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.reply.domain.comment.Comment;
 import com.recipetory.reply.domain.review.Review;
@@ -15,8 +15,8 @@ import com.recipetory.user.domain.follow.Follow;
 import com.recipetory.user.domain.follow.FollowRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -24,40 +24,40 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 @RequiredArgsConstructor
 public class RecipetoryEventListener {
-    private final NotificationRepository notificationRepository;
-    private final FollowRepository followRepository;
+    private final NotificationMessageSender notificationMessageSender;
 
     /**
      * 팔로워들에게 레시피 작성을 알린다.
      * @param createRecipeEvent
      */
     @TransactionalEventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(readOnly = true)
+    @Async
     public void handleCreateRecipeEvent(CreateRecipeEvent createRecipeEvent) {
+        // 생성된 레시피, 알림 종류 정보 구성
         Recipe createdRecipe = createRecipeEvent.getRecipe();
         User author = createdRecipe.getAuthor();
+        NotificationType type = NotificationType.NEW_RECIPE;
 
-        log.info("{} creates recipe {}", author.getId(), createdRecipe.getId());
+        // logging
+        log.info("{} created recipe {}", author.getId(), createdRecipe.getId());
 
-        followRepository.findByFollowed(author)
-                .forEach(follow -> {
-                    User follower = follow.getFollowing();
+        NotificationMessage message = NotificationMessage.builder()
+                .notificationType(NotificationType.NEW_RECIPE)
+                .path(NotificationType.NEW_RECIPE.getDefaultPath(author.getId()))
+                .senderId(author.getId()).build();
 
-                    notificationRepository.save(Notification.builder()
-                            .sender(author).receiver(follower)
-                            .notificationType(NotificationType.NEW_RECIPE)
-                            .message(NotificationType.NEW_RECIPE.getDefaultMessage(author))
-                            .path("/recipes/" + createdRecipe.getId())
-                            .build());
-                });
+        notificationMessageSender.sendNotificationMessage(message);
+
     }
 
     /**
-     * 팔로우 알림
+     * 팔로우 당한 사람에게 팔로우 알림
      * @param followEvent
      */
     @TransactionalEventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(readOnly = true)
+    @Async
     public void handleFollowEvent(FollowEvent followEvent) {
         Follow follow = followEvent.getFollow();
         User sender = follow.getFollowing();
@@ -65,53 +65,58 @@ public class RecipetoryEventListener {
 
         log.info("{} follows {}", sender.getId(), receiver.getId());
 
-        notificationRepository.save(Notification.builder()
+        NotificationMessage message = NotificationMessage.builder()
                 .notificationType(NotificationType.FOLLOW)
-                .sender(sender).receiver(receiver)
-                .message(NotificationType.FOLLOW.getDefaultMessage(sender))
-                .path("/"+sender.getId())
-                .build());
+                .path(NotificationType.FOLLOW.getDefaultPath(sender.getId()))
+                .senderId(sender.getId()).receiverId(receiver.getId())
+                .build();
+
+        notificationMessageSender.sendNotificationMessage(message);
     }
 
     /**
-     * 댓글 알림
+     * 레시피를 작성한 사람에게 댓글 알림
      * @param createCommentEvent
      */
     @TransactionalEventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleCommentEvent(CreateCommentEvent createCommentEvent) {
+    @Transactional(readOnly = true)
+    @Async
+    public void handleCreateCommentEvent(CreateCommentEvent createCommentEvent) {
         Comment comment = createCommentEvent.getComment();
         User sender = comment.getAuthor();
         User receiver = comment.getRecipe().getAuthor();
+        NotificationType type = NotificationType.COMMENT;
 
         log.info("{} comments {}", sender.getId(), comment.getId());
 
-        notificationRepository.save(Notification.builder()
-                .sender(sender).receiver(receiver)
-                .notificationType(NotificationType.COMMENT)
-                .message(NotificationType.COMMENT.getDefaultMessage(sender))
-                .path("/comment/" + comment.getId())
-                .build());
+        NotificationMessage message = NotificationMessage.builder()
+                .notificationType(type).path(type.getDefaultPath(comment.getId()))
+                .senderId(sender.getId()).receiverId(receiver.getId())
+                .build();
+
+        notificationMessageSender.sendNotificationMessage(message);
     }
 
     /**
-     * 리뷰 알림
+     * 레시피를 작성한 사람에게 리뷰 알림
      * @param createReviewEvent
      */
     @TransactionalEventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleCommentEvent(CreateReviewEvent createReviewEvent) {
+    @Transactional(readOnly = true)
+    @Async
+    public void handleCreateReviewEvent(CreateReviewEvent createReviewEvent) {
         Review review = createReviewEvent.getReview();
         User sender = review.getAuthor();
         User receiver = review.getRecipe().getAuthor();
+        NotificationType type = NotificationType.REVIEW;
 
         log.info("{} reviewed {}", sender.getId(), review.getId());
 
-        notificationRepository.save(Notification.builder()
-                .sender(sender).receiver(receiver)
-                .notificationType(NotificationType.REVIEW)
-                .message(NotificationType.REVIEW.getDefaultMessage(sender))
-                .path("/review/" + review.getId())
-                .build());
+        NotificationMessage message = NotificationMessage.builder()
+                .notificationType(type).path(type.getDefaultPath(review.getId()))
+                .senderId(sender.getId()).receiverId(receiver.getId())
+                .build();
+
+        notificationMessageSender.sendNotificationMessage(message);
     }
 }

--- a/src/main/java/com/recipetory/notification/domain/NotificationMessageSender.java
+++ b/src/main/java/com/recipetory/notification/domain/NotificationMessageSender.java
@@ -1,0 +1,7 @@
+package com.recipetory.notification.domain;
+
+import com.recipetory.notification.presentation.dto.NotificationMessage;
+
+public interface NotificationMessageSender {
+    void sendNotificationMessage(NotificationMessage message);
+}

--- a/src/main/java/com/recipetory/notification/domain/NotificationType.java
+++ b/src/main/java/com/recipetory/notification/domain/NotificationType.java
@@ -9,15 +9,19 @@ import java.util.function.Function;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationType {
-    NEW_RECIPE((sender) -> sender + "님이 새 레시피를 작성하셨습니다."),
-    FOLLOW((sender) -> sender + "님이 나를 팔로우합니다."),
-    COMMENT((sender) -> sender + "님이 나의 레시피에 댓글을 달았습니다."),
-    REVIEW((sender) -> sender + "님이 나의 레시피에 리뷰를 달았습니다."),
-    ETC((sender) -> sender + "님으로부터의 알림");
+    NEW_RECIPE((sender) -> sender + "님이 새 레시피를 작성하셨습니다.", (id) -> "/recipes/" + id),
+    FOLLOW((sender) -> sender + "님이 나를 팔로우합니다.", (id) -> "/" + id),
+    COMMENT((sender) -> sender + "님이 나의 레시피에 댓글을 달았습니다.", (id) -> "/comments/" + id),
+    REVIEW((sender) -> sender + "님이 나의 레시피에 리뷰를 달았습니다.", (id) -> "/reviews/" + id),
+    ETC((sender) -> sender + "님으로부터의 알림", (id) -> "/" + id);
 
     private final Function<String, String> defaultMessage;
+    public final Function<Long, String> defaultPath;
 
     public String getDefaultMessage(User sender) {
         return defaultMessage.apply(sender.getName());
+    }
+    public String getDefaultPath(Long id) {
+        return defaultPath.apply(id);
     }
 }

--- a/src/main/java/com/recipetory/notification/infrastructure/KafkaNotificationListener.java
+++ b/src/main/java/com/recipetory/notification/infrastructure/KafkaNotificationListener.java
@@ -1,0 +1,84 @@
+package com.recipetory.notification.infrastructure;
+
+import com.recipetory.config.kafka.KafkaTopic;
+import com.recipetory.notification.domain.Notification;
+import com.recipetory.notification.domain.NotificationRepository;
+import com.recipetory.notification.domain.NotificationType;
+import com.recipetory.notification.presentation.dto.NotificationMessage;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.UserRepository;
+import com.recipetory.user.domain.follow.FollowRepository;
+import com.recipetory.utils.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class KafkaNotificationListener {
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+
+    /**
+     * 도착한 message 정보를 토대로 notification save를 진행한다.
+     * @param notificationMessage sent kafka message
+     */
+    @KafkaListener(topics = KafkaTopic.NOTIFICATION,
+            containerFactory = "notificationKafkaListenerContainerFactory",
+            groupId = "${spring.kafka.group-id}")
+    @Transactional
+    public void notificationListener(NotificationMessage notificationMessage) {
+        NotificationType type = notificationMessage.getNotificationType();
+
+        if (type == NotificationType.NEW_RECIPE) {
+            // 팔로워들 전체에게 알림
+            saveNotificationToFollowers(notificationMessage);
+        } else {
+            saveNotification(notificationMessage);
+        }
+    }
+
+    @Transactional
+    public void saveNotificationToFollowers(NotificationMessage notificationMessage) {
+        User sender = getUserById(notificationMessage.getSenderId());
+        NotificationType type = notificationMessage.getNotificationType();
+
+        followRepository.findByFollowed(sender).forEach(follow -> {
+            User receiver = follow.getFollowing();
+
+            Notification notification = Notification.builder()
+                    .sender(sender).receiver(receiver)
+                    .message(type.getDefaultMessage(sender))
+                    .path(notificationMessage.getPath())
+                    .notificationType(type).build();
+
+            notificationRepository.save(notification);
+        });
+    }
+
+    @Transactional
+    public void saveNotification(NotificationMessage notificationMessage) {
+        User sender = getUserById(notificationMessage.getSenderId());
+        User receiver = getUserById(notificationMessage.getReceiverId());
+        NotificationType type = notificationMessage.getNotificationType();
+
+        Notification notification = Notification.builder()
+                .sender(sender).receiver(receiver)
+                .message(type.getDefaultMessage(sender))
+                .path(notificationMessage.getPath())
+                .notificationType(type).build();
+
+        notificationRepository.save(notification);
+    }
+
+    @Transactional
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "User", String.valueOf(userId)));
+    }
+}

--- a/src/main/java/com/recipetory/notification/infrastructure/KafkaNotificationMessageSender.java
+++ b/src/main/java/com/recipetory/notification/infrastructure/KafkaNotificationMessageSender.java
@@ -19,13 +19,10 @@ public class KafkaNotificationMessageSender implements NotificationMessageSender
 
     @Override
     public void sendNotificationMessage(NotificationMessage message) {
-        CompletableFuture<SendResult<String, NotificationMessage>> future =
-                kafkaTemplate.send(KafkaTopic.NOTIFICATION, message);
-
-        future.whenComplete((result, ex) -> {
-            if (ex != null) {
-                log.warn("message sent failed!", ex);
-            }
-        });
+        kafkaTemplate.send(message.getTopic(), message)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.warn("message sent failed!", ex);
+                    }});
     }
 }

--- a/src/main/java/com/recipetory/notification/infrastructure/KafkaNotificationMessageSender.java
+++ b/src/main/java/com/recipetory/notification/infrastructure/KafkaNotificationMessageSender.java
@@ -1,0 +1,31 @@
+package com.recipetory.notification.infrastructure;
+
+import com.recipetory.config.kafka.KafkaTopic;
+import com.recipetory.notification.domain.NotificationMessageSender;
+import com.recipetory.notification.presentation.dto.NotificationMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaNotificationMessageSender implements NotificationMessageSender {
+    private final KafkaTemplate<String, NotificationMessage> kafkaTemplate;
+
+    @Override
+    public void sendNotificationMessage(NotificationMessage message) {
+        CompletableFuture<SendResult<String, NotificationMessage>> future =
+                kafkaTemplate.send(KafkaTopic.NOTIFICATION, message);
+
+        future.whenComplete((result, ex) -> {
+            if (ex != null) {
+                log.warn("message sent failed!", ex);
+            }
+        });
+    }
+}

--- a/src/main/java/com/recipetory/notification/presentation/dto/NotificationMessage.java
+++ b/src/main/java/com/recipetory/notification/presentation/dto/NotificationMessage.java
@@ -1,0 +1,21 @@
+package com.recipetory.notification.presentation.dto;
+
+import com.recipetory.notification.domain.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * kafka로 전송될 Serializable messsage dto
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationMessage {
+    private Long senderId;
+    private Long receiverId;
+    private NotificationType notificationType;
+    private String path;
+}

--- a/src/main/java/com/recipetory/notification/presentation/dto/NotificationMessage.java
+++ b/src/main/java/com/recipetory/notification/presentation/dto/NotificationMessage.java
@@ -1,5 +1,7 @@
 package com.recipetory.notification.presentation.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.recipetory.config.kafka.KafkaTopic;
 import com.recipetory.notification.domain.NotificationType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,4 +20,8 @@ public class NotificationMessage {
     private Long receiverId;
     private NotificationType notificationType;
     private String path;
+
+    // 메세지가 전송될 kafka topic
+    @JsonIgnore
+    private String topic;
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,7 @@
 spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    group-id: recipetory-local
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${MYSQL_HOST}:3306/recipetory?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
@@ -8,7 +11,7 @@ spring:
     properties:
       hibernate:
         default_batch_fetch_size: 1000
-        show_sql: true
+#        show_sql: true
     hibernate:
       ddl-auto: update
   security:

--- a/src/main/resources/application-server.yml
+++ b/src/main/resources/application-server.yml
@@ -1,4 +1,7 @@
 spring:
+  kafka:
+    bootstrap-servers: 10.178.0.7:9092, 10.178.0.8:9092, 10.178.0.9:9092
+    group-id: recipetory
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://10.178.0.3:3306/recipetory?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8

--- a/src/test/java/com/recipetory/notification/application/NotificationTest.java
+++ b/src/test/java/com/recipetory/notification/application/NotificationTest.java
@@ -7,12 +7,6 @@ import com.recipetory.recipe.application.RecipeService;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.recipe.domain.RecipeInfo;
 import com.recipetory.recipe.domain.RecipeStatistics;
-import com.recipetory.reply.application.CommentService;
-import com.recipetory.reply.application.ReviewService;
-import com.recipetory.reply.domain.comment.Comment;
-import com.recipetory.reply.domain.review.Review;
-import com.recipetory.reply.presentation.comment.dto.CreateCommentDto;
-import com.recipetory.reply.presentation.review.dto.CreateReviewDto;
 import com.recipetory.user.application.FollowService;
 import com.recipetory.user.domain.Role;
 import com.recipetory.user.domain.User;
@@ -30,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
@@ -38,8 +33,7 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 @AutoConfigureTestDatabase
 @EmbeddedKafka(partitions = 4,
         brokerProperties = {
-                "listeners=PLAINTEXT://localhost:9092",
-                "port=9092" })
+                "listeners=PLAINTEXT://localhost:9092" })
 // @DirtiesContext : spring boot test에서 application context를 재사용하는 것을 막아줌
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class NotificationTest {
@@ -47,10 +41,6 @@ class NotificationTest {
     private FollowService followService;
     @Autowired
     private RecipeService recipeService;
-    @Autowired
-    private CommentService commentService;
-    @Autowired
-    private ReviewService reviewService;
     @Autowired
     private UserRepository userRepository;
     @Autowired
@@ -75,115 +65,24 @@ class NotificationTest {
 
         TestTransaction.flagForCommit();
         TestTransaction.end();
-        TestTransaction.start();
 
-        // then : sender가 author, receiver가 follower인 NEW_RECIPE 알림이 1개 생성된다.
-        await().atMost(3, TimeUnit.SECONDS)
+        // then : sender가 author, receiver가 follower인 NEW_RECIPE 알림이 1개
+        //        sender가 follower, receiver가 author인 FOLLOW 알림이 1개 생성된다.
+        await().atMost(2, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
-                    assertEquals(1,
-                            notificationRepository.findByReceiver(follower).size()); // 1개
-                });
-        Notification notification = notificationRepository.findByReceiver(follower).get(0);
-        assertEquals(author.getId(),notification.getSender().getId()); // sender
-        assertEquals(NotificationType.NEW_RECIPE, notification.getNotificationType()); // NEW_RECIPE
-    }
-
-    @Test
-    @DisplayName("팔로우를 하면 팔로우 당한 사람에게 알림이 생성된다.")
-    public void followNotificationTest() {
-        // given : 팔로우 당하는 followed, 팔로우 하는 follower 유저가 존재한다.
-        User followed = userRepository.save(User.builder()
-                .name("author").email("author@test.com").role(Role.USER).build());
-        User follower = userRepository.save(User.builder()
-                .name("follower1").email("follower1@test.com").role(Role.USER).build());
-
-        // when : follower 유저가 followed 유저를 팔로우한다.
-        followService.follow(follower.getEmail(),followed.getId());
-
-        // TransactionalEventListener를 사용중이기 때문에, 이전 transaction commit 필요
-        TestTransaction.flagForCommit();
-        TestTransaction.end();
-        TestTransaction.start();
-
-        // then : sender가 follower, receiver가 followed인 FOLLOW 알림이 1개 생성된다.
-        await().atMost(3, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    assertEquals(1,
-                            notificationRepository.findByReceiver(followed).size()); // 1개
+                    assertAll(
+                            () -> assertEquals(
+                                    1, notificationRepository.findByReceiver(follower).size()),
+                            () -> assertEquals(
+                                    1, notificationRepository.findByReceiver(author).size()));
                 });
 
-        Notification notification = notificationRepository.findByReceiver(followed).get(0);
-        assertEquals(follower.getId(), notification.getSender().getId()); // sender
-        assertEquals(NotificationType.FOLLOW, notification.getNotificationType()); // FOLLOW
-    }
+        Notification createRecipenotification = notificationRepository.findByReceiver(follower).get(0);
+        assertEquals(author.getId(),createRecipenotification.getSender().getId()); // sender
+        assertEquals(NotificationType.NEW_RECIPE, createRecipenotification.getNotificationType()); // NEW_RECIPE
 
-    @Test
-    @DisplayName("레시피 작성자에게 댓글 작성 알림이 생성된다.")
-    public void commentNotificationTest() {
-        // given : recipeAuthor 유저가 recipe 레시피를 생성한다.
-        User recipeAuthor = userRepository.save(User.builder()
-                .name("recipeAuthor").email("recipeAutho@test.com").role(Role.USER).build());
-        Recipe recipe = Recipe.builder()
-                .title("test").recipeInfo(new RecipeInfo()).recipeStatistics(new RecipeStatistics())
-                .steps(new ArrayList<>()).tags(new ArrayList<>()).ingredients(new ArrayList<>())
-                .build();
-        recipeService.createRecipe(recipe,new ArrayList<>(),recipeAuthor.getEmail());
-
-        // when : commentAuthor 유저가 댓글을 생성한다.
-        User commentAuthor = userRepository.save(User.builder()
-                .name("commentAuthor").email("commentAuthor@test.com").role(Role.USER).build());
-        Comment comment = commentService.createComment(commentAuthor.getEmail(), new CreateCommentDto(
-                recipe.getId(),"test comment"));
-
-        // TransactionalEventListener 사용중이기 때문에, 이전 transaction commit 필요
-        TestTransaction.flagForCommit();
-        TestTransaction.end();
-        TestTransaction.start();
-
-        // then : sender가 commentAuthor, receiver가 recipeAuthor인 COMMENT 알림이 1개 생성된다.
-        await().atMost(3, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    assertEquals(1,
-                            notificationRepository.findByReceiver(recipeAuthor).size()); // 1개
-                });
-
-        Notification notification = notificationRepository.findByReceiver(recipeAuthor).get(0);
-        assertEquals(commentAuthor.getId(), notification.getSender().getId()); // sender
-        assertEquals(NotificationType.COMMENT, notification.getNotificationType()); // COMMENT
-    }
-
-    @Test
-    @DisplayName("레시피 작성자에게 리뷰 작성 알림이 생성된다.")
-    public void reviewNotificationTest() {
-        // given : recipeAuthor 유저가 레시피를 생성한다.
-        User recipeAuthor = userRepository.save(User.builder()
-                .name("recipeAuthor").email("recipeAutho@test.com").role(Role.USER).build());
-        Recipe recipe = Recipe.builder()
-                .title("test").recipeInfo(new RecipeInfo()).recipeStatistics(new RecipeStatistics())
-                .steps(new ArrayList<>()).tags(new ArrayList<>()).ingredients(new ArrayList<>())
-                .build();
-        recipeService.createRecipe(recipe,new ArrayList<>(),recipeAuthor.getEmail());
-
-        // when : reviewAuthor 유저가 리뷰를 생성한다.
-        User reviewAuthor = userRepository.save(User.builder()
-                .name("reviewAuthor").email("reviewAuthor@test.com").role(Role.USER).build());
-        Review review = reviewService.createReview(reviewAuthor.getEmail(), new CreateReviewDto(
-                recipe.getId(),30,"test review"));
-
-        // TransactionalEventListener 사용중이기 때문에, 이전 transaction commit 필요
-        TestTransaction.flagForCommit();
-        TestTransaction.end();
-        TestTransaction.start();
-
-        // then : sender가 reviewAuthor, receiver가 recipeAuthor인 COMMENT 알림이 1개 생성된다.
-        await().atMost(30, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    assertEquals(1,
-                            notificationRepository.findByReceiver(recipeAuthor).size()); // 1개
-                });
-
-        Notification notification = notificationRepository.findByReceiver(recipeAuthor).get(0);
-        assertEquals(reviewAuthor.getId(), notification.getSender().getId());
-        assertEquals(NotificationType.REVIEW, notification.getNotificationType());
+        Notification followNotification = notificationRepository.findByReceiver(author).get(0);
+        assertEquals(follower.getId(), followNotification.getSender().getId());
+        assertEquals(NotificationType.FOLLOW, followNotification.getNotificationType());
     }
 }

--- a/src/test/java/com/recipetory/recipe/application/RecipeServiceIntegrationTest.java
+++ b/src/test/java/com/recipetory/recipe/application/RecipeServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    group-id: recipetory-test
+    consumer:
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000
+#        show_sql: true
+    hibernate:
+      ddl-auto: update


### PR DESCRIPTION
## 개요
저번 세션때 말씀드렸던 `@Transactional(propagation = REQUIRES_NEW)`때문에 "하나의 스레드가 2개 이상의 커넥션을 점유"하는 상황 데드락을 어떻게 막아보았습니다. 하지만 .. -이전에 보이던 데드락이 없었다- 뿐이지 결국 post 여러번 보내다보면 timeout이 발생하네유.

<img width="807" alt="image" src="https://github.com/f-lab-edu/recipetory/assets/69233405/f5bc2997-778c-401f-b370-eabfd6b3e945">


## 작업사항
- GCP 카프카 인스턴스 3개를 띄웠는데요,(`appplication-server.yml`에서 확인 가능) 3개 연결하겠다고 시도한 것에 비한 보람은 좀 적네요^^;
- Jpa가 Repository 인터페이스를 구현하는데 사용되는 것처럼, MessageSender 인터페이스를 구현하는데 KafkaTemplate을 이용했다고 해야할까요.. 카프카는 구체적 기술이라 생각해서 infrastructure쪽에 두었고, eventPublisher쪽에서 이를 이용하게 하기 위해 카프카가 사용되는 `messageSend()`메소드를 가진 인터페이스를 도메인 패키지에 두었서요.
- 카프카에 보내지는 직렬화용 메세지 클래스는 `NotificationMessage`입니다.. `"notification"` 토픽으로 보내진 메세지를 `@KafkaListener` 메소드가 consume한다.. 정도로 생각하고 구성했어요.
- 알림이 보내지는 상황이 [sender / receiver가 정해짐], [한명의 sender / 여러명의 팔로워] 이렇게 나뉘어져있어서 토픽을 나눠야하나, key를 나눠야하나 고민을 하다가 일단 알림 메세지의 `NotificationType`항목을 토대로 `if`문을 작성했습니다....


## 테스트!!
- 비동기 로직에 대한 테스트를 어떻게 짜야하는지 모르겠네요ㄱ-. 현재는 카프카 message sending이 필요한 통합 테스트에서 `await().atMost().untilAsserted()`로 어떻게 삐걱이면서도 되도록 만들었는데, 이래도 될까? 까지는 잘 모르겠습니다😭
