### PR TITLE
Recipe 검색 기능 고도화에 Elastic Search 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
@@ -36,6 +38,8 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/recipetory/config/ElasticSearchConfig.java
+++ b/src/main/java/com/recipetory/config/ElasticSearchConfig.java
@@ -1,0 +1,37 @@
+package com.recipetory.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+public class ElasticSearchConfig {
+    @Value("#{'${spring.data.elasticsearch.hosts}'.split(',')}")
+    private List<String> hosts;
+
+    @Value("${spring.data.elasticsearch.port}")
+    private int port;
+
+    @Bean
+    public ElasticsearchClient restClient() {
+        List<HttpHost> hostList = new ArrayList<>();
+        for (String host : hosts) {
+            hostList.add(new HttpHost(host, port, "http"));
+        }
+
+        RestClient client = RestClient.builder(
+                hostList.toArray(new HttpHost[hostList.size()]))
+                .build();
+        ElasticsearchTransport transport = new RestClientTransport(client, new JacksonJsonpMapper());
+        return new ElasticsearchClient(transport);
+    }
+}

--- a/src/main/java/com/recipetory/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaConsumerConfig.java
@@ -3,6 +3,7 @@ package com.recipetory.config.kafka;
 import com.recipetory.notification.presentation.dto.NotificationMessage;
 import com.recipetory.recipe.domain.document.RecipeDocument;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -81,6 +82,36 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, RecipeDocument> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(documentConsumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, Long> deleteDocumentConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                bootstrapAddress);
+        props.put(
+                ConsumerConfig.GROUP_ID_CONFIG,
+                groupId);
+        props.put(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class);
+        props.put(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                LongDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(props,
+                new StringDeserializer(),
+                new LongDeserializer());
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Long>
+    deleteDocumentKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Long> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(deleteDocumentConsumerFactory());
         return factory;
     }
 }

--- a/src/main/java/com/recipetory/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaConsumerConfig.java
@@ -1,6 +1,7 @@
 package com.recipetory.config.kafka;
 
 import com.recipetory.notification.presentation.dto.NotificationMessage;
+import com.recipetory.recipe.domain.document.RecipeDocument;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,6 +51,36 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, NotificationMessage> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(notificationConsumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, RecipeDocument> documentConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                bootstrapAddress);
+        props.put(
+                ConsumerConfig.GROUP_ID_CONFIG,
+                groupId);
+        props.put(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class);
+        props.put(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                JsonDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(props,
+                new StringDeserializer(),
+                new JsonDeserializer<>(RecipeDocument.class));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, RecipeDocument>
+    recipeDocumentKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, RecipeDocument> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(documentConsumerFactory());
         return factory;
     }
 }

--- a/src/main/java/com/recipetory/config/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaProducerConfig.java
@@ -3,6 +3,7 @@ package com.recipetory.config.kafka;
 import com.recipetory.notification.presentation.dto.NotificationMessage;
 import com.recipetory.recipe.domain.document.RecipeDocument;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -54,6 +55,22 @@ public class KafkaProducerConfig {
     }
 
     @Bean
+    public ProducerFactory<String, Long> deleteDocumentProducerFactory() {
+        Map<String,Object> configProps = new HashMap<>();
+        configProps.put(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                bootstrapAddress);
+        configProps.put(
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class);
+        configProps.put(
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                LongSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
     public KafkaTemplate<String, NotificationMessage> notificationKafkaTemplate() {
         return new KafkaTemplate<>(notificationProducerFactory());
     }
@@ -65,5 +82,14 @@ public class KafkaProducerConfig {
     @Bean
     public KafkaTemplate<String, RecipeDocument> recipeDocumentKafkaTemplate() {
         return new KafkaTemplate<>(documentProducerFactory());
+    }
+
+    /**
+     * Document delete시 kafka message를 보내는 Template
+     * @return
+     */
+    @Bean
+    public KafkaTemplate<String, Long> deleteDocumentKafkaTemplate() {
+        return new KafkaTemplate<>(deleteDocumentProducerFactory());
     }
 }

--- a/src/main/java/com/recipetory/config/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaProducerConfig.java
@@ -1,6 +1,7 @@
 package com.recipetory.config.kafka;
 
 import com.recipetory.notification.presentation.dto.NotificationMessage;
+import com.recipetory.recipe.domain.document.RecipeDocument;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,7 +38,32 @@ public class KafkaProducerConfig {
     }
 
     @Bean
+    public ProducerFactory<String, RecipeDocument> documentProducerFactory() {
+        Map<String,Object> configProps = new HashMap<>();
+        configProps.put(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                bootstrapAddress);
+        configProps.put(
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class);
+        configProps.put(
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
     public KafkaTemplate<String, NotificationMessage> notificationKafkaTemplate() {
         return new KafkaTemplate<>(notificationProducerFactory());
+    }
+
+    /**
+     * Document create / update시 kafka message를 보내는 Template
+     * @return
+     */
+    @Bean
+    public KafkaTemplate<String, RecipeDocument> recipeDocumentKafkaTemplate() {
+        return new KafkaTemplate<>(documentProducerFactory());
     }
 }

--- a/src/main/java/com/recipetory/config/kafka/KafkaTopic.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaTopic.java
@@ -4,4 +4,5 @@ public interface KafkaTopic {
     public final String NOTIFICATION = "notification";
     public final String FOLLOWER_NOTIFICATION = "follower-notification";
     public final String NEW_RECIPE = "new-recipe";
+    public final String DELETE_RECIPE = "delete-recipe";
 }

--- a/src/main/java/com/recipetory/config/kafka/KafkaTopic.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaTopic.java
@@ -3,4 +3,5 @@ package com.recipetory.config.kafka;
 public interface KafkaTopic {
     public final String NOTIFICATION = "notification";
     public final String FOLLOWER_NOTIFICATION = "follower-notification";
+    public final String NEW_RECIPE = "new-recipe";
 }

--- a/src/main/java/com/recipetory/config/kafka/KafkaTopicConfig.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaTopicConfig.java
@@ -36,4 +36,9 @@ public class KafkaTopicConfig {
     public NewTopic createRecipeTopic() {
         return new NewTopic(KafkaTopic.NEW_RECIPE, 2, (short) 2);
     }
+
+    @Bean
+    public NewTopic deleteRecipeTopic() {
+        return new NewTopic(KafkaTopic.DELETE_RECIPE, 2, (short) 2);
+    }
 }

--- a/src/main/java/com/recipetory/config/kafka/KafkaTopicConfig.java
+++ b/src/main/java/com/recipetory/config/kafka/KafkaTopicConfig.java
@@ -31,4 +31,9 @@ public class KafkaTopicConfig {
     public NewTopic followNotificationTopic() {
         return new NewTopic(KafkaTopic.FOLLOWER_NOTIFICATION, 2, (short) 2);
     }
+
+    @Bean
+    public NewTopic createRecipeTopic() {
+        return new NewTopic(KafkaTopic.NEW_RECIPE, 2, (short) 2);
+    }
 }

--- a/src/main/java/com/recipetory/notification/domain/event/DeleteRecipeEvent.java
+++ b/src/main/java/com/recipetory/notification/domain/event/DeleteRecipeEvent.java
@@ -1,0 +1,10 @@
+package com.recipetory.notification.domain.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteRecipeEvent {
+    private Long recipeId;
+}

--- a/src/main/java/com/recipetory/notification/infrastructure/KafkaNotificationListener.java
+++ b/src/main/java/com/recipetory/notification/infrastructure/KafkaNotificationListener.java
@@ -32,7 +32,8 @@ public class KafkaNotificationListener {
             containerFactory = "notificationKafkaListenerContainerFactory",
             groupId = "${spring.kafka.group-id}")
     @Transactional
-    public void notificationListener(NotificationMessage notificationMessage) {
+    public void saveNotification(NotificationMessage notificationMessage) {
+        log.info("notification message consume : {}",notificationMessage.getPath());
         NotificationType type = notificationMessage.getNotificationType();
         User sender = getUserById(notificationMessage.getSenderId());
         User receiver = getUserById(notificationMessage.getReceiverId());
@@ -54,7 +55,8 @@ public class KafkaNotificationListener {
             containerFactory = "notificationKafkaListenerContainerFactory",
             groupId = "${spring.kafka.group-id}")
     @Transactional
-    public void followerNotificationListener(NotificationMessage notificationMessage) {
+    public void saveFollowerNotification(NotificationMessage notificationMessage) {
+        log.info("follower-notification message consume : {}",notificationMessage.getPath());
         NotificationType type = notificationMessage.getNotificationType();
         User sender = getUserById(notificationMessage.getSenderId());
 

--- a/src/main/java/com/recipetory/recipe/application/RecipeSearchService.java
+++ b/src/main/java/com/recipetory/recipe/application/RecipeSearchService.java
@@ -1,0 +1,80 @@
+package com.recipetory.recipe.application;
+
+import com.recipetory.recipe.domain.*;
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import com.recipetory.recipe.presentation.dto.RecipeListDto;
+import com.recipetory.tag.domain.TagName;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.UserRepository;
+import com.recipetory.utils.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RecipeSearchService {
+    private final RecipeRepository recipeRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 인자로 들어온 userId의 유저가 작성한 레시피를 반환한다.
+     * @param userId
+     * @return {@link RecipeListDto}
+     */
+    @Transactional(readOnly = true)
+    public RecipeListDto findByUserId(Long userId) {
+        User author = userRepository.findById(userId).orElseThrow(
+                () -> new EntityNotFoundException("User", String.valueOf(userId)));
+        List<RecipeDocument> found = recipeRepository.findByAuthor(author);
+        return RecipeListDto.fromDocumentList(found);
+    }
+
+    /**
+     * 인자로 들어온 String tag를 모두 포함하는 레시피를 조회한다.
+     * @param tags {@link String} tag
+     * @return {@link RecipeListDto}
+     */
+    @Transactional(readOnly = true)
+    public RecipeListDto findByTags(List<String> tags) {
+        // string tags를 tagName enum 타입으로 변환
+        List<TagName> tagNames = convertToTagName(tags);
+        // tagName List 전부를 포함하는 recipe 검색
+        List<RecipeDocument> found = recipeRepository
+                .findByTagNames(tagNames);
+
+        return RecipeListDto.fromDocumentList(found);
+    }
+
+    /**
+     * 인자로 들어온 조건에 맞는 레시피를 검색한다.
+     * @param title
+     * @param cookingTime
+     * @param difficulty
+     * @param serving
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public RecipeListDto findRecipeByRecipeInfo(
+            String title, String cookingTime, String difficulty, String serving) {
+        List<RecipeDocument> found = recipeRepository.findByRecipeInfo(
+                title,
+                CookingTime.fromString(cookingTime),
+                Difficulty.fromString(difficulty),
+                Serving.fromString(serving));
+        return RecipeListDto.fromDocumentList(found);
+    }
+
+    private List<TagName> convertToTagName(List<String> tags) {
+        List<TagName> tagNames = new ArrayList<>();
+        tags.forEach(tag ->
+            TagName.fromString(tag)
+                    .ifPresent(tagNames::add));
+        return tagNames;
+    }
+}

--- a/src/main/java/com/recipetory/recipe/application/RecipeService.java
+++ b/src/main/java/com/recipetory/recipe/application/RecipeService.java
@@ -6,10 +6,8 @@ import com.recipetory.ingredient.presentation.dto.RecipeIngredientDto;
 import com.recipetory.notification.domain.event.CreateRecipeEvent;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.recipe.domain.RecipeRepository;
+import com.recipetory.recipe.domain.document.RecipeDocument;
 import com.recipetory.recipe.presentation.dto.RecipeDto;
-import com.recipetory.recipe.presentation.dto.RecipeListDto;
-import com.recipetory.step.domain.Step;
-import com.recipetory.tag.domain.Tag;
 import com.recipetory.user.domain.Role;
 import com.recipetory.user.domain.User;
 import com.recipetory.user.domain.UserRepository;
@@ -20,7 +18,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -66,15 +63,8 @@ public class RecipeService {
      */
     @Transactional
     public RecipeDto getCompleteRecipe(Long recipeId) {
-        Recipe found = getRecipeById(recipeId);
-        User author = found.getAuthor();
-        List<Step> steps = found.getSteps();
-        List<RecipeIngredient> ingredients = found.getIngredients();
-        List<Tag> tags = found.getTags();
-
-        RecipeDto recipeDto = RecipeDto.fromEntity(found);
-        recipeDto.setRelations(author, steps, ingredients, tags);
-        return recipeDto;
+        RecipeDocument found = recipeRepository.getDocumentById(recipeId);
+        return RecipeDto.fromDocument(found);
     }
 
     /**
@@ -86,21 +76,6 @@ public class RecipeService {
     public Recipe getRecipeById(Long recipeId) {
         return recipeRepository.findById(recipeId)
                 .orElseThrow(() -> new EntityNotFoundException("Recipe", String.valueOf(recipeId)));
-    }
-
-    /**
-     * 인자로 들어온 문자열을 title에 포함한 레시피를 검색한다.
-     * @param word search keyword
-     * @return recipe list dto
-     */
-    @Transactional(readOnly = true)
-    public RecipeListDto findRecipeByTitleContains(String word) {
-        if (word.isEmpty()) {
-            return RecipeListDto.fromEntityList(new ArrayList<>());
-        }
-
-        List<Recipe> found = recipeRepository.findByTitleContains(word);
-        return RecipeListDto.fromEntityList(found);
     }
 
     /**

--- a/src/main/java/com/recipetory/recipe/domain/CookingTime.java
+++ b/src/main/java/com/recipetory/recipe/domain/CookingTime.java
@@ -1,7 +1,10 @@
 package com.recipetory.recipe.domain;
 
+import com.recipetory.tag.domain.TagName;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
 
 @RequiredArgsConstructor
 @Getter
@@ -16,4 +19,11 @@ public enum CookingTime {
     UNDEFINED("선택안함");
 
     private final String description;
+
+    public static CookingTime fromString(String input) {
+        return Arrays.stream(CookingTime.values())
+                .filter(cookingTime -> cookingTime.name()
+                        .equalsIgnoreCase(input))
+                .findAny().orElse(UNDEFINED);
+    }
 }

--- a/src/main/java/com/recipetory/recipe/domain/Difficulty.java
+++ b/src/main/java/com/recipetory/recipe/domain/Difficulty.java
@@ -3,6 +3,8 @@ package com.recipetory.recipe.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+
 @RequiredArgsConstructor
 @Getter
 public enum Difficulty {
@@ -12,4 +14,11 @@ public enum Difficulty {
     UNDEFINED("선택안함");
 
     private final String description;
+
+    public static Difficulty fromString(String input) {
+        return Arrays.stream(Difficulty.values())
+                .filter(difficulty -> difficulty.name()
+                        .equalsIgnoreCase(input))
+                .findAny().orElse(UNDEFINED);
+    }
 }

--- a/src/main/java/com/recipetory/recipe/domain/RecipeRepository.java
+++ b/src/main/java/com/recipetory/recipe/domain/RecipeRepository.java
@@ -1,16 +1,28 @@
 package com.recipetory.recipe.domain;
 
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import com.recipetory.tag.domain.TagName;
+import com.recipetory.user.domain.User;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface RecipeRepository {
-    Optional<Recipe> findByTitle(String title);
-
     Recipe save(Recipe recipe);
 
     Optional<Recipe> findById(Long id);
 
-    List<Recipe> findByTitleContains(String title);
+    RecipeDocument getDocumentById(Long id);
+
+    List<RecipeDocument> findByRecipeInfo(
+            String title,
+            CookingTime cookingTime,
+            Difficulty difficulty,
+            Serving serving);
+
+    List<RecipeDocument> findByAuthor(User author);
+
+    List<RecipeDocument> findByTagNames(List<TagName> tagNames);
 
     void deleteById(Long id);
 }

--- a/src/main/java/com/recipetory/recipe/domain/Serving.java
+++ b/src/main/java/com/recipetory/recipe/domain/Serving.java
@@ -3,6 +3,8 @@ package com.recipetory.recipe.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+
 @Getter
 @RequiredArgsConstructor
 public enum Serving {
@@ -14,4 +16,11 @@ public enum Serving {
     UNDEFINED("선택안함");
 
     private final String description;
+
+    public static Serving fromString(String input) {
+        return Arrays.stream(Serving.values())
+                .filter(serving -> serving.name()
+                        .equalsIgnoreCase(input))
+                .findAny().orElse(UNDEFINED);
+    }
 }

--- a/src/main/java/com/recipetory/recipe/domain/document/IngredientDocument.java
+++ b/src/main/java/com/recipetory/recipe/domain/document/IngredientDocument.java
@@ -1,0 +1,34 @@
+package com.recipetory.recipe.domain.document;
+
+import com.recipetory.ingredient.domain.RecipeIngredient;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * recipe document의 nested field
+ */
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class IngredientDocument {
+    private String name;
+    private String amount;
+
+    private static IngredientDocument fromEntity(RecipeIngredient recipeIngredient) {
+        return IngredientDocument.builder()
+                .name(recipeIngredient.getIngredient().getName())
+                .amount(recipeIngredient.getAmount())
+                .build();
+    }
+
+    public static List<IngredientDocument> fromEntityList(
+            List<RecipeIngredient> recipeIngredients) {
+        return recipeIngredients.stream()
+                .map(IngredientDocument::fromEntity).toList();
+    }
+}

--- a/src/main/java/com/recipetory/recipe/domain/document/RecipeDocument.java
+++ b/src/main/java/com/recipetory/recipe/domain/document/RecipeDocument.java
@@ -1,0 +1,72 @@
+package com.recipetory.recipe.domain.document;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.recipe.domain.RecipeInfo;
+import com.recipetory.recipe.domain.RecipeStatistics;
+import com.recipetory.tag.domain.TagName;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Setting(settingPath = "/elasticsearch/settings/settings.json")
+@Document(indexName = "recipe")
+public class RecipeDocument {
+    @Id @Field(type = FieldType.Long)
+    private Long id;
+
+    @Field(type = FieldType.Long)
+    private Long authorId;
+
+    @Field(type = FieldType.Text,
+            analyzer = "korean")
+    private String title;
+
+    @Field(type = FieldType.Nested)
+    private RecipeInfo recipeInfo;
+
+    @Field(type = FieldType.Nested)
+    private RecipeStatistics recipeStatistics;
+
+    @Field(type = FieldType.Nested)
+    private List<StepDocument> steps;
+
+    @Field(type = FieldType.Nested)
+    private List<IngredientDocument> ingredients;
+
+    @Field(type = FieldType.Keyword)
+    private List<TagName> tags;
+
+    @Field(type = FieldType.Date,
+            format = {DateFormat.date_hour_minute_second_millis,
+                    DateFormat.epoch_millis})
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    LocalDateTime createdAt;
+
+    public static RecipeDocument fromEntity(Recipe recipe) {
+        return RecipeDocument.builder()
+                .id(recipe.getId()).authorId(recipe.getAuthor().getId())
+                .title(recipe.getTitle())
+                .recipeInfo(recipe.getRecipeInfo())
+                .recipeStatistics(recipe.getRecipeStatistics())
+                .steps(StepDocument.fromEntityList(recipe.getSteps()))
+                .ingredients(IngredientDocument.fromEntityList(recipe.getIngredients()))
+                .createdAt(recipe.getCreatedAt()).build();
+    }
+}

--- a/src/main/java/com/recipetory/recipe/domain/document/StepDocument.java
+++ b/src/main/java/com/recipetory/recipe/domain/document/StepDocument.java
@@ -1,0 +1,30 @@
+package com.recipetory.recipe.domain.document;
+
+import com.recipetory.step.domain.Step;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * recipe document의 nested field
+ */
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class StepDocument {
+    private int stepNumber;
+    private String description;
+
+    private static StepDocument fromEntity(Step step) {
+        return StepDocument.builder()
+                .stepNumber(step.getStepNumber()).description(step.getDescription())
+                .build();
+    }
+    static List<StepDocument> fromEntityList(List<Step> steps) {
+        return steps.stream().map(StepDocument::fromEntity).toList();
+    }
+}

--- a/src/main/java/com/recipetory/recipe/infrastructure/RecipeDocumentQueryService.java
+++ b/src/main/java/com/recipetory/recipe/infrastructure/RecipeDocumentQueryService.java
@@ -1,0 +1,104 @@
+package com.recipetory.recipe.infrastructure;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import com.recipetory.recipe.domain.CookingTime;
+import com.recipetory.recipe.domain.Difficulty;
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import com.recipetory.recipe.domain.Serving;
+import com.recipetory.tag.domain.TagName;
+import com.recipetory.utils.exception.EsClientException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RecipeDocumentQueryService {
+    private final ElasticsearchClient esClient;
+
+    /**
+     * 인자로 주어진 tagName List의 tag가 "전부" 포함된 RecipeDocument를 반환한다.
+     * @param tagNames
+     * @return
+     */
+    public List<RecipeDocument> findByTagNames(List<TagName> tagNames) {
+        List<Query> tagQueries = tagNames.stream().map(tagName ->
+            TermQuery.of(q -> q.field("tags")
+                            .value(tagName.name()))._toQuery())
+                .toList();
+
+        try {
+            SearchResponse<RecipeDocument> response = esClient.search(
+                    s -> s.index("recipe").query(
+                            q -> q.bool(
+                                    b -> b.must(tagQueries))),
+                    RecipeDocument.class
+            );
+            return response.hits().hits().stream().map(Hit::source).toList();
+        } catch (IOException e) {
+            throw new EsClientException("recipe");
+        }
+    }
+
+    /**
+     * 메소드 인자로 주어진 항목과 일치하는 Recipe를 반환한다.
+     * title이 빈 문자열이거나, enum type이 UNDEFINED라면 검색 조건에 포함하지 않는다.
+     * @param title
+     * @param cookingTime
+     * @param difficulty
+     * @param serving
+     * @return
+     */
+    public List<RecipeDocument> findByRecipeInfo(
+            String title, CookingTime cookingTime, Difficulty difficulty, Serving serving
+    ) {
+        // title이 빈칸이거나, recipeInfo 항목 타입이 UNDEFIEND이면 검색 조건에서 제외
+        List<Query> infoQueries = new ArrayList<>();
+        if (title != "") {
+            infoQueries.add(MatchQuery.of(q ->
+                    q.field("title").query(title))._toQuery());
+        }
+        if (cookingTime != CookingTime.UNDEFINED) {
+            System.out.println("undefined가 아니빈다!");
+            infoQueries.add(NestedQuery.of(
+                    n -> n.path("recipeInfo").query(
+                            q -> q.match(
+                                    s -> s.field("recipeInfo.cookingTime")
+                                            .query(cookingTime.name()))))._toQuery());
+        }
+        if (difficulty != Difficulty.UNDEFINED) {
+            infoQueries.add(NestedQuery.of(n ->
+                    n.path("recipeInfo").query(
+                            q -> q.match(
+                                    s -> s.field("recipeInfo.difficulty")
+                                            .query(difficulty.name()))))._toQuery());
+        }
+        if (serving != Serving.UNDEFINED) {
+            infoQueries.add(NestedQuery.of(n ->
+                    n.path("recipeInfo").query(
+                            q -> q.match(
+                                    s -> s.field("recipeInfo.serving")
+                                            .query(serving.name()))))._toQuery());
+        }
+
+        try {
+            SearchResponse<RecipeDocument> response = esClient.search(
+                    s -> s.index("recipe")
+                            .query(q -> q.bool(
+                                    b -> b.must(infoQueries))),
+                    RecipeDocument.class);
+            return response.hits().hits().stream().map(Hit::source).toList();
+        } catch (IOException e) {
+            throw new EsClientException("recipe");
+        }
+    }
+}

--- a/src/main/java/com/recipetory/recipe/infrastructure/RecipeDocumentQueryService.java
+++ b/src/main/java/com/recipetory/recipe/infrastructure/RecipeDocumentQueryService.java
@@ -1,16 +1,14 @@
 package com.recipetory.recipe.infrastructure;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
-import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.recipetory.recipe.domain.CookingTime;
 import com.recipetory.recipe.domain.Difficulty;
-import com.recipetory.recipe.domain.document.RecipeDocument;
 import com.recipetory.recipe.domain.Serving;
+import com.recipetory.recipe.domain.document.RecipeDocument;
 import com.recipetory.tag.domain.TagName;
 import com.recipetory.utils.exception.EsClientException;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RecipeDocumentQueryService {
     private final ElasticsearchClient esClient;
+    private final RecipeQueryHelper recipeQueryHelper;
 
     /**
      * 인자로 주어진 tagName List의 tag가 "전부" 포함된 RecipeDocument를 반환한다.
@@ -63,32 +62,13 @@ public class RecipeDocumentQueryService {
     ) {
         // title이 빈칸이거나, recipeInfo 항목 타입이 UNDEFIEND이면 검색 조건에서 제외
         List<Query> infoQueries = new ArrayList<>();
-        if (title != "") {
-            infoQueries.add(MatchQuery.of(q ->
-                    q.field("title").query(title))._toQuery());
-        }
-        if (cookingTime != CookingTime.UNDEFINED) {
-            System.out.println("undefined가 아니빈다!");
-            infoQueries.add(NestedQuery.of(
-                    n -> n.path("recipeInfo").query(
-                            q -> q.match(
-                                    s -> s.field("recipeInfo.cookingTime")
-                                            .query(cookingTime.name()))))._toQuery());
-        }
-        if (difficulty != Difficulty.UNDEFINED) {
-            infoQueries.add(NestedQuery.of(n ->
-                    n.path("recipeInfo").query(
-                            q -> q.match(
-                                    s -> s.field("recipeInfo.difficulty")
-                                            .query(difficulty.name()))))._toQuery());
-        }
-        if (serving != Serving.UNDEFINED) {
-            infoQueries.add(NestedQuery.of(n ->
-                    n.path("recipeInfo").query(
-                            q -> q.match(
-                                    s -> s.field("recipeInfo.serving")
-                                            .query(serving.name()))))._toQuery());
-        }
+        infoQueries.add(recipeQueryHelper.buildTitleQuery(title));
+        infoQueries.add(recipeQueryHelper.buildRecipeInfoQuery(
+                "recipeInfo.cookingTime", cookingTime.name()));
+        infoQueries.add(recipeQueryHelper.buildRecipeInfoQuery(
+                "recipeInfo.difficulty", difficulty.name()));
+        infoQueries.add(recipeQueryHelper.buildRecipeInfoQuery(
+                "recipeInfo.serving", serving.name()));
 
         try {
             SearchResponse<RecipeDocument> response = esClient.search(

--- a/src/main/java/com/recipetory/recipe/infrastructure/RecipeDocumentRepository.java
+++ b/src/main/java/com/recipetory/recipe/infrastructure/RecipeDocumentRepository.java
@@ -1,0 +1,12 @@
+package com.recipetory.recipe.infrastructure;
+
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RecipeDocumentRepository extends ElasticsearchRepository<RecipeDocument, Long> {
+    List<RecipeDocument> findByAuthorId(Long authorId);
+}

--- a/src/main/java/com/recipetory/recipe/infrastructure/RecipeJpaRepository.java
+++ b/src/main/java/com/recipetory/recipe/infrastructure/RecipeJpaRepository.java
@@ -1,7 +1,15 @@
 package com.recipetory.recipe.infrastructure;
 
+import com.recipetory.recipe.domain.CookingTime;
+import com.recipetory.recipe.domain.Difficulty;
 import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.recipe.domain.Serving;
+import com.recipetory.tag.domain.TagName;
+import com.recipetory.user.domain.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +18,34 @@ public interface RecipeJpaRepository extends JpaRepository<Recipe,Long> {
     Optional<Recipe> findByTitle(String title);
 
     List<Recipe> findByTitleContains(String title);
+
+    List<Recipe> findByAuthor(User author);
+
+    /**
+     * tagNames의 tagName을 전부 포함하는 레시피들을 검색한다.
+     * @param tagNames
+     * @param tagSize
+     * @return
+     */
+    @Query("SELECT DISTINCT r FROM Recipe r " +
+            "JOIN FETCH r.author WHERE " +
+            ":tagSize > 0 AND :tagSize = " +
+            "(SELECT COUNT(t) FROM Tag t WHERE " +
+            "t.recipe = r AND t.tagName IN :tagNames)")
+    List<Recipe> findByTags(
+            @Param("tagNames") List<TagName> tagNames,
+            @Param("tagSize") int tagSize,
+            Pageable pageable);
+
+    @Query("SELECT DISTINCT r FROM Recipe r " +
+            "JOIN FETCH r.author " +
+            "WHERE r.title LIKE %:title% " +
+            "AND (r.recipeInfo.cookingTime = :cookingTime OR :cookingTime = 'UNDEFINED')" +
+            "AND (r.recipeInfo.difficulty = :difficulty OR :difficulty = 'UNDEFINED')" +
+            "AND (r.recipeInfo.serving = :serving OR :serving = 'UNDEFINED')")
+    List<Recipe> findByRecipeInfo(
+            @Param("title") String title,
+            @Param("cookingTime") CookingTime cookingTime,
+            @Param("difficulty") Difficulty difficulty,
+            @Param("serving") Serving serving);
 }

--- a/src/main/java/com/recipetory/recipe/infrastructure/RecipeQueryHelper.java
+++ b/src/main/java/com/recipetory/recipe/infrastructure/RecipeQueryHelper.java
@@ -1,0 +1,43 @@
+package com.recipetory.recipe.infrastructure;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RecipeQueryHelper {
+    /**
+     * title 문자열에 대한 match query를 반환한다.
+     * 인자로 주어진 title이 빈 문자열일 경우 조건에 포함하지 않는다.
+     * @param title
+     * @return
+     */
+    public Query buildTitleQuery(String title) {
+        BoolQuery.Builder boolQuery = QueryBuilders.bool();
+        if (title != "") {
+            return boolQuery.must(MatchQuery.of(q ->
+                    q.field("title").query(title))._toQuery()).build()._toQuery();
+        } else {
+            return boolQuery.build()._toQuery();
+        }
+    }
+
+    /**
+     * RecipeInfo 항목에 대한 match query를 반환한다.
+     * 검색하고자 하는 nested fieldName과 enum name을 인자로 받는다.
+     * 인자로 들어온 enum value name이 UNDEFINED일 경우 조건에 포함하지 않는다.
+     * @param fieldName nested field name
+     * @param name enum value name
+     * @return
+     */
+    public Query buildRecipeInfoQuery(String fieldName, String name) {
+        BoolQuery.Builder boolQuery = QueryBuilders.bool();
+        if (name != "UNDEFINED") {
+            NestedQuery.Builder nestedQuery =
+                    QueryBuilders.nested().path("recipeInfo").query(
+                            q -> q.match(
+                                    s -> s.field(fieldName).query(name)));
+            boolQuery.must(b -> b.nested(nestedQuery.build()));
+        }
+        return boolQuery.build()._toQuery();
+    }
+}

--- a/src/main/java/com/recipetory/recipe/infrastructure/RecipeRepositoryImpl.java
+++ b/src/main/java/com/recipetory/recipe/infrastructure/RecipeRepositoryImpl.java
@@ -55,6 +55,5 @@ public class RecipeRepositoryImpl implements RecipeRepository {
     @Override
     public void deleteById(Long id) {
         recipeJpaRepository.deleteById(id);
-        recipeDocumentRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/recipetory/recipe/infrastructure/RecipeRepositoryImpl.java
+++ b/src/main/java/com/recipetory/recipe/infrastructure/RecipeRepositoryImpl.java
@@ -1,7 +1,10 @@
 package com.recipetory.recipe.infrastructure;
 
-import com.recipetory.recipe.domain.Recipe;
-import com.recipetory.recipe.domain.RecipeRepository;
+import com.recipetory.recipe.domain.*;
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import com.recipetory.tag.domain.TagName;
+import com.recipetory.user.domain.User;
+import com.recipetory.utils.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -13,11 +16,8 @@ import java.util.Optional;
 public class RecipeRepositoryImpl implements RecipeRepository {
 
     private final RecipeJpaRepository recipeJpaRepository;
-
-    @Override
-    public Optional<Recipe> findByTitle(String title) {
-        return recipeJpaRepository.findByTitle(title);
-    }
+    private final RecipeDocumentRepository recipeDocumentRepository;
+    private final RecipeDocumentQueryService recipeQueryService;
 
     @Override
     public Recipe save(Recipe recipe) {
@@ -30,12 +30,31 @@ public class RecipeRepositoryImpl implements RecipeRepository {
     }
 
     @Override
-    public List<Recipe> findByTitleContains(String title) {
-        return recipeJpaRepository.findByTitleContains(title);
+    public RecipeDocument getDocumentById(Long id) {
+        return recipeDocumentRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Recipe", String.valueOf(id)));
+    }
+
+    @Override
+    public List<RecipeDocument> findByRecipeInfo(
+            String title, CookingTime cookingTime, Difficulty difficulty, Serving serving
+    ) {
+        return recipeQueryService.findByRecipeInfo(title, cookingTime, difficulty, serving);
+    }
+
+    @Override
+    public List<RecipeDocument> findByAuthor(User author) {
+        return recipeDocumentRepository.findByAuthorId(author.getId());
+    }
+
+    @Override
+    public List<RecipeDocument> findByTagNames(List<TagName> tagNames) {
+        return recipeQueryService.findByTagNames(tagNames);
     }
 
     @Override
     public void deleteById(Long id) {
         recipeJpaRepository.deleteById(id);
+        recipeDocumentRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/recipetory/recipe/presentation/RecipeController.java
+++ b/src/main/java/com/recipetory/recipe/presentation/RecipeController.java
@@ -66,9 +66,10 @@ public class RecipeController {
      */
     @DeleteMapping("/recipes/{recipeId}")
     public ResponseEntity<Void> deleteRecipe(
-            @PathVariable("recipeId") Long recipeId
+            @PathVariable("recipeId") Long recipeId,
+            @LogInUser SessionUser logInUser
     ) {
-        recipeService.deleteRecipeById(recipeId);
+        recipeService.deleteRecipeById(recipeId,logInUser.getEmail());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/recipetory/recipe/presentation/RecipeController.java
+++ b/src/main/java/com/recipetory/recipe/presentation/RecipeController.java
@@ -3,6 +3,7 @@ package com.recipetory.recipe.presentation;
 import com.recipetory.config.auth.argumentresolver.LogInUser;
 import com.recipetory.config.auth.dto.SessionUser;
 import com.recipetory.ingredient.presentation.dto.RecipeIngredientDto;
+import com.recipetory.recipe.application.RecipeSearchService;
 import com.recipetory.recipe.application.RecipeService;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.recipe.presentation.dto.CreateRecipeDto;
@@ -17,11 +18,11 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/recipes")
 @RequiredArgsConstructor
 @Slf4j
 public class RecipeController {
     private final RecipeService recipeService;
+    private final RecipeSearchService recipeSearchService;
 
     /**
      * request body로 요청된 recipe를 생성한다.
@@ -29,7 +30,7 @@ public class RecipeController {
      * @param logInUser
      * @return
      */
-    @PostMapping
+    @PostMapping("/recipes")
     public ResponseEntity<CreateRecipeDto.Response> postRecipe(
             @RequestBody @Valid CreateRecipeDto.Request request,
             @LogInUser SessionUser logInUser) {
@@ -50,7 +51,7 @@ public class RecipeController {
      * @param recipeId
      * @return
      */
-    @GetMapping("/{recipeId}")
+    @GetMapping("/recipes/{recipeId}")
     public ResponseEntity<RecipeDto> findByRecipeId(
             @PathVariable("recipeId") Long recipeId) {
 
@@ -59,25 +60,11 @@ public class RecipeController {
     }
 
     /**
-     * query parameter의 문자열을 title에 포함한 레시피를 검색한다.
-     * @param keyWord 검색 문자열
-     * @return recipe list dto
-     */
-    @GetMapping
-    public ResponseEntity<RecipeListDto> searchRecipe(
-            @RequestParam(name = "q", defaultValue = "") String keyWord
-    ) {
-        RecipeListDto found = recipeService.findRecipeByTitleContains(
-                keyWord.trim());
-        return ResponseEntity.ok(found);
-    }
-
-    /**
      * path variable에 해당하는 id를 가진 레시피를 삭제한다.
      * @param recipeId path variable
      * @return
      */
-    @DeleteMapping("/{recipeId}")
+    @DeleteMapping("/recipes/{recipeId}")
     public ResponseEntity<Void> deleteRecipe(
             @PathVariable("recipeId") Long recipeId
     ) {

--- a/src/main/java/com/recipetory/recipe/presentation/RecipeSearchController.java
+++ b/src/main/java/com/recipetory/recipe/presentation/RecipeSearchController.java
@@ -41,7 +41,7 @@ public class RecipeSearchController {
      */
     @GetMapping("/recipes")
     public ResponseEntity<RecipeListDto> searchRecipe(
-            @RequestParam(name = "q", defaultValue = "UNDEFINED") String title,
+            @RequestParam(name = "q", defaultValue = "") String title,
             @RequestParam(name = "t", defaultValue = "UNDEFINED") String cookingTime,
             @RequestParam(name = "d", defaultValue = "UNDEFINED") String difficulty,
             @RequestParam(name = "s", defaultValue = "UNDEFINED") String serving

--- a/src/main/java/com/recipetory/recipe/presentation/RecipeSearchController.java
+++ b/src/main/java/com/recipetory/recipe/presentation/RecipeSearchController.java
@@ -1,0 +1,66 @@
+package com.recipetory.recipe.presentation;
+
+import com.recipetory.recipe.application.RecipeSearchService;
+import com.recipetory.recipe.presentation.dto.RecipeListDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class RecipeSearchController {
+    private final RecipeSearchService recipeSearchService;
+
+    /**
+     * path variable의 userId가 작성한 recipe를 반환한다.
+     * @param userId
+     * @return
+     */
+    @GetMapping("/{userId}/recipes")
+    public ResponseEntity<RecipeListDto> findByUserId(
+            @PathVariable("userId") Long userId
+    ) {
+        RecipeListDto found = recipeSearchService.findByUserId(userId);
+        return ResponseEntity.ok(found);
+    }
+
+    /**
+     * title과 recipeInfo 조건에 맞는 레시피를 검색한다.
+     * @param title
+     * @param cookingTime
+     * @param difficulty
+     * @param serving
+     * @return
+     */
+    @GetMapping("/recipes")
+    public ResponseEntity<RecipeListDto> searchRecipe(
+            @RequestParam(name = "q", defaultValue = "UNDEFINED") String title,
+            @RequestParam(name = "t", defaultValue = "UNDEFINED") String cookingTime,
+            @RequestParam(name = "d", defaultValue = "UNDEFINED") String difficulty,
+            @RequestParam(name = "s", defaultValue = "UNDEFINED") String serving
+    ) {
+        RecipeListDto found = recipeSearchService.findRecipeByRecipeInfo(
+                title.trim(), cookingTime, difficulty, serving);
+        return ResponseEntity.ok(found);
+    }
+
+    /**
+     * query parameter로 들어온 tag를 전부 포함하는 레시피를 검색한다.
+     * @param tags
+     * @return
+     */
+    @GetMapping("/recipes/tags")
+    public ResponseEntity<RecipeListDto> searchRecipeByTags(
+            @RequestParam(name = "t", defaultValue = "") List<String> tags
+    ) {
+        RecipeListDto found = recipeSearchService.findByTags(tags);
+        return ResponseEntity.ok(found);
+    }
+}

--- a/src/main/java/com/recipetory/recipe/presentation/dto/RecipeDto.java
+++ b/src/main/java/com/recipetory/recipe/presentation/dto/RecipeDto.java
@@ -6,9 +6,11 @@ import com.recipetory.ingredient.presentation.dto.RecipeIngredientDto;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.recipe.domain.RecipeInfo;
 import com.recipetory.recipe.domain.RecipeStatistics;
+import com.recipetory.recipe.domain.document.RecipeDocument;
 import com.recipetory.step.domain.Step;
 import com.recipetory.step.presentation.dto.StepDto;
 import com.recipetory.tag.domain.Tag;
+import com.recipetory.tag.domain.TagName;
 import com.recipetory.tag.presentation.dto.TagDto;
 import com.recipetory.user.domain.User;
 import com.recipetory.user.presentation.dto.UserDto;
@@ -34,7 +36,7 @@ public class RecipeDto {
     private UserDto author;
     private List<StepDto> steps;
     private List<RecipeIngredientDto> ingredients;
-    private List<TagDto> tags;
+    private List<TagName> tags;
 
     /**
      * entity로부터 기본적인 레시피 정보를 dto로 변환한다.
@@ -64,6 +66,15 @@ public class RecipeDto {
         this.ingredients = ingredients.stream()
                 .map(RecipeIngredientDto::fromEntity).toList();
         this.tags = tags.stream()
-                .map(TagDto::fromEntity).toList();
+                .map(Tag::getTagName).toList();
+    }
+
+    public static RecipeDto fromDocument(RecipeDocument recipe) {
+        return RecipeDto.builder()
+                .id(recipe.getId()).title(recipe.getTitle())
+                .information(recipe.getRecipeInfo())
+                .statistics(recipe.getRecipeStatistics())
+                .steps(recipe.getSteps().stream().map(StepDto::fromDocument).toList())
+                .tags(recipe.getTags()).build();
     }
 }

--- a/src/main/java/com/recipetory/recipe/presentation/dto/RecipeListDto.java
+++ b/src/main/java/com/recipetory/recipe/presentation/dto/RecipeListDto.java
@@ -1,6 +1,7 @@
 package com.recipetory.recipe.presentation.dto;
 
 import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.recipe.domain.document.RecipeDocument;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,13 @@ public class RecipeListDto {
     public static RecipeListDto fromEntityList(List<Recipe> recipes) {
         List<RecipeDto> recipeDtos = recipes.stream()
                 .map(RecipeDto::fromEntity).toList();
+
+        return new RecipeListDto(recipeDtos);
+    }
+
+    public static RecipeListDto fromDocumentList(List<RecipeDocument> recipes) {
+        List<RecipeDto> recipeDtos = recipes.stream()
+                .map(RecipeDto::fromDocument).toList();
 
         return new RecipeListDto(recipeDtos);
     }

--- a/src/main/java/com/recipetory/step/presentation/dto/StepDto.java
+++ b/src/main/java/com/recipetory/step/presentation/dto/StepDto.java
@@ -1,5 +1,6 @@
 package com.recipetory.step.presentation.dto;
 
+import com.recipetory.recipe.domain.document.StepDocument;
 import com.recipetory.step.domain.Step;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
@@ -33,6 +34,13 @@ public class StepDto {
     public Step toEntity() {
         return Step.builder()
                 .stepNumber(stepNumber).description(description)
+                .build();
+    }
+
+    public static StepDto fromDocument(StepDocument stepDocument) {
+        return StepDto.builder()
+                .stepNumber(stepDocument.getStepNumber())
+                .description(stepDocument.getDescription())
                 .build();
     }
 }

--- a/src/main/java/com/recipetory/tag/domain/TagName.java
+++ b/src/main/java/com/recipetory/tag/domain/TagName.java
@@ -3,6 +3,9 @@ package com.recipetory.tag.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Getter
 public enum TagName {
@@ -39,4 +42,10 @@ public enum TagName {
 
     private final String korean;
     private final TagType tagType;
+
+    public static Optional<TagName> fromString(String input) {
+        return Arrays.stream(TagName.values()).filter(
+                tagName -> tagName.name().equalsIgnoreCase(input))
+                .findAny();
+    }
 }

--- a/src/main/java/com/recipetory/tag/presentation/TagController.java
+++ b/src/main/java/com/recipetory/tag/presentation/TagController.java
@@ -37,19 +37,6 @@ public class TagController {
     }
 
     /**
-     * 특정 tag의 레시피를 검색한다
-     * @param tagName
-     * @return
-     */
-    @GetMapping("/tags")
-    public ResponseEntity<RecipeListDto> getRecipesByTagName(
-            @RequestParam(name = "tag", required = true) TagName tagName
-    ) {
-        List<Recipe> recipes = tagService.getRecipeByTag(tagName);
-        return ResponseEntity.ok(RecipeListDto.fromEntityList(recipes));
-    }
-
-    /**
      * 특정 레시피의 태그 목록을 불러온다.
      * @param recipeId
      * @return

--- a/src/main/java/com/recipetory/utils/BaseTimeEntity.java
+++ b/src/main/java/com/recipetory/utils/BaseTimeEntity.java
@@ -14,8 +14,8 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
     @CreatedDate
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 }

--- a/src/main/java/com/recipetory/utils/es/CreateDocumentListener.java
+++ b/src/main/java/com/recipetory/utils/es/CreateDocumentListener.java
@@ -1,0 +1,32 @@
+package com.recipetory.utils.es;
+
+import com.recipetory.notification.domain.event.*;
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * entity가 작성, 혹은 수정될 때 kafka에 생성될 es document를 message로 send
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CreateDocumentListener {
+    private final KafkaDocumentMessageSender documentMessageSender;
+
+    /**
+     * 생성된 recipe Entity를 ES에 반영하기 위해 kafka message를 보낸다.
+     * @param createRecipeEvent
+     */
+    @TransactionalEventListener
+    @Async
+    public void createRecipeDocument(CreateRecipeEvent createRecipeEvent) {
+        RecipeDocument document = RecipeDocument.fromEntity(
+                createRecipeEvent.getRecipe());
+
+        documentMessageSender.sendRecipeDocument(document);
+    }
+}

--- a/src/main/java/com/recipetory/utils/es/DocumentListener.java
+++ b/src/main/java/com/recipetory/utils/es/DocumentListener.java
@@ -30,6 +30,10 @@ public class DocumentListener {
         documentMessageSender.sendRecipeDocument(document);
     }
 
+    /**
+     * 삭제된 recipe Entity를 document에도 반영하기 위해 kafka message를 보낸다.
+     * @param deleteRecipeEvent
+     */
     @TransactionalEventListener
     @Async
     public void deleteRecipeDocument(DeleteRecipeEvent deleteRecipeEvent) {

--- a/src/main/java/com/recipetory/utils/es/DocumentListener.java
+++ b/src/main/java/com/recipetory/utils/es/DocumentListener.java
@@ -14,7 +14,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class CreateDocumentListener {
+public class DocumentListener {
     private final KafkaDocumentMessageSender documentMessageSender;
 
     /**
@@ -28,5 +28,12 @@ public class CreateDocumentListener {
                 createRecipeEvent.getRecipe());
 
         documentMessageSender.sendRecipeDocument(document);
+    }
+
+    @TransactionalEventListener
+    @Async
+    public void deleteRecipeDocument(DeleteRecipeEvent deleteRecipeEvent) {
+        documentMessageSender.sendDeleteRecipeDocument(
+                deleteRecipeEvent.getRecipeId());
     }
 }

--- a/src/main/java/com/recipetory/utils/es/KafkaDocumentListener.java
+++ b/src/main/java/com/recipetory/utils/es/KafkaDocumentListener.java
@@ -26,6 +26,10 @@ public class KafkaDocumentListener {
         recipeDocumentRepository.save(document);
     }
 
+    /**
+     * Kafka message로 도착한 RecipeDocument id를 삭제한다.
+     * @param recipeId
+     */
     @KafkaListener(topics = KafkaTopic.DELETE_RECIPE,
             containerFactory = "deleteDocumentKafkaListenerContainerFactory",
             groupId = "${spring.kafka.group-id}")

--- a/src/main/java/com/recipetory/utils/es/KafkaDocumentListener.java
+++ b/src/main/java/com/recipetory/utils/es/KafkaDocumentListener.java
@@ -1,0 +1,28 @@
+package com.recipetory.utils.es;
+
+import com.recipetory.config.kafka.KafkaTopic;
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import com.recipetory.recipe.infrastructure.RecipeDocumentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class KafkaDocumentListener {
+    private final RecipeDocumentRepository recipeDocumentRepository;
+
+    /**
+     * Kafka message로 도착한 RecipeDocument를 indexing한다.
+     * @param document kafkaMessgae
+     */
+    @KafkaListener(topics = KafkaTopic.NEW_RECIPE,
+            containerFactory = "recipeDocumentKafkaListenerContainerFactory",
+            groupId = "${spring.kafka.group-id}")
+    public void documentListener(RecipeDocument document) {
+        log.info("recipe document id {} 저장", document.getId());
+        recipeDocumentRepository.save(document);
+    }
+}

--- a/src/main/java/com/recipetory/utils/es/KafkaDocumentListener.java
+++ b/src/main/java/com/recipetory/utils/es/KafkaDocumentListener.java
@@ -25,4 +25,12 @@ public class KafkaDocumentListener {
         log.info("recipe document id {} 저장", document.getId());
         recipeDocumentRepository.save(document);
     }
+
+    @KafkaListener(topics = KafkaTopic.DELETE_RECIPE,
+            containerFactory = "deleteDocumentKafkaListenerContainerFactory",
+            groupId = "${spring.kafka.group-id}")
+    public void deleteDocumentListener(Long recipeId) {
+        log.info("recipe document id {} 삭제",recipeId);
+        recipeDocumentRepository.deleteById(recipeId);
+    }
 }

--- a/src/main/java/com/recipetory/utils/es/KafkaDocumentMessageSender.java
+++ b/src/main/java/com/recipetory/utils/es/KafkaDocumentMessageSender.java
@@ -1,0 +1,24 @@
+package com.recipetory.utils.es;
+
+import com.recipetory.config.kafka.KafkaTopic;
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaDocumentMessageSender {
+    private final KafkaTemplate<String, RecipeDocument> documentKafkaTemplate;
+
+    public void sendRecipeDocument(RecipeDocument document) {
+        documentKafkaTemplate.send(KafkaTopic.NEW_RECIPE, document)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.warn("document message sent failed!", ex);
+                    }});
+    }
+}

--- a/src/main/java/com/recipetory/utils/es/KafkaDocumentMessageSender.java
+++ b/src/main/java/com/recipetory/utils/es/KafkaDocumentMessageSender.java
@@ -1,7 +1,6 @@
 package com.recipetory.utils.es;
 
 import com.recipetory.config.kafka.KafkaTopic;
-import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.recipe.domain.document.RecipeDocument;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,12 +12,21 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class KafkaDocumentMessageSender {
     private final KafkaTemplate<String, RecipeDocument> documentKafkaTemplate;
+    private final KafkaTemplate<String, Long> deleteDocumentKafkaTemplate;
 
     public void sendRecipeDocument(RecipeDocument document) {
         documentKafkaTemplate.send(KafkaTopic.NEW_RECIPE, document)
                 .whenComplete((result, ex) -> {
                     if (ex != null) {
                         log.warn("document message sent failed!", ex);
+                    }});
+    }
+
+    public void sendDeleteRecipeDocument(Long recipeId) {
+        deleteDocumentKafkaTemplate.send(KafkaTopic.DELETE_RECIPE,recipeId)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.warn("delete document message sent failed!", ex);
                     }});
     }
 }

--- a/src/main/java/com/recipetory/utils/exception/EsClientException.java
+++ b/src/main/java/com/recipetory/utils/exception/EsClientException.java
@@ -1,0 +1,10 @@
+package com.recipetory.utils.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EsClientException extends RuntimeException {
+    private final String indexName;
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,13 +7,17 @@ spring:
     url: jdbc:mysql://${MYSQL_HOST}:3306/recipetory?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
     password: ${MYSQL_PW}
+  data:
+    elasticsearch:
+      hosts: localhost
+      port: 9200
   jpa:
     properties:
       hibernate:
         default_batch_fetch_size: 1000
 #        show_sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
   security:
     oauth2:
       client:

--- a/src/main/resources/application-server.yml
+++ b/src/main/resources/application-server.yml
@@ -7,6 +7,10 @@ spring:
     url: jdbc:mysql://10.178.0.3:3306/recipetory?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
     password: ${MYSQL_PW}
+  data:
+    elasticsearch:
+      hosts: 10.178.0.10,10.178.0.11
+      port: 9200
   jpa:
     properties:
       hibernate:

--- a/src/main/resources/elasticsearch/settings/settings.json
+++ b/src/main/resources/elasticsearch/settings/settings.json
@@ -1,0 +1,15 @@
+{
+  "analysis": {
+    "tokenizer": {
+      "nori_none": {
+        "type": "nori_tokenizer",
+        "decompound_mode": "none"
+      }
+    },
+    "analyzer": {
+      "korean": {
+        "type": "nori"
+      }
+    }
+  }
+}

--- a/src/test/java/com/recipetory/notification/application/NotificationTest.java
+++ b/src/test/java/com/recipetory/notification/application/NotificationTest.java
@@ -1,8 +1,8 @@
 package com.recipetory.notification.application;
 
-import com.recipetory.notification.domain.Notification;
-import com.recipetory.notification.domain.NotificationRepository;
+import com.recipetory.notification.domain.NotificationMessageSender;
 import com.recipetory.notification.domain.NotificationType;
+import com.recipetory.notification.presentation.dto.NotificationMessage;
 import com.recipetory.recipe.application.RecipeService;
 import com.recipetory.recipe.domain.Recipe;
 import com.recipetory.recipe.domain.RecipeInfo;
@@ -11,32 +11,35 @@ import com.recipetory.user.application.FollowService;
 import com.recipetory.user.domain.Role;
 import com.recipetory.user.domain.User;
 import com.recipetory.user.domain.UserRepository;
+import com.recipetory.user.domain.follow.Follow;
+import com.recipetory.user.domain.follow.FollowRepository;
+import com.recipetory.user.service.TestFollowRepository;
+import com.recipetory.user.service.TestUserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.context.EmbeddedKafka;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 @SpringBootTest
-@Transactional
 @AutoConfigureTestDatabase
-@EmbeddedKafka(partitions = 4,
-        brokerProperties = {
-                "listeners=PLAINTEXT://localhost:9092" })
-// @DirtiesContext : spring boot test에서 application context를 재사용하는 것을 막아줌
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@EmbeddedKafka(brokerProperties = {
+        "listeners=PLAINTEXT://localhost:9093" })
 class NotificationTest {
+    @MockBean
+    private NotificationMessageSender notificationMessageSender;
     @Autowired
     private FollowService followService;
     @Autowired
@@ -44,45 +47,72 @@ class NotificationTest {
     @Autowired
     private UserRepository userRepository;
     @Autowired
-    private NotificationRepository notificationRepository;
+    private FollowRepository followRepository;
 
     @Test
-    @DisplayName("레시피를 작성하면 팔로워들에게 알림이 생성된다.")
-    public void createdRecipeNotificationTest() {
-        // given : author 유저를 follower가 팔로우한다.
+    @Transactional
+    @DisplayName("레시피를 작성하면 팔로워들에게 알림 메세지가 발송된다.")
+    public void createRecipeNotificationTest() {
+        // given : author 유저와 그를 팔로우하는 follower 유저가 존재한다.
         User author = userRepository.save(User.builder()
                 .name("author").email("author@test.com").role(Role.USER).build());
         User follower = userRepository.save(User.builder()
-                .name("follower1").email("follower1@test.com").role(Role.USER).build());
-        followService.follow(follower.getEmail(),author.getId());
+                .name("follower").email("follower@test.com").role(Role.USER).build());
+        followRepository.save(Follow.builder()
+                .followed(author).following(follower).build());
 
-        // when : author 유저가 새로운 레시피를 작성한다.
+        // when : author 유저가 레시피를 작성한다.
         Recipe recipe = Recipe.builder()
                 .title("test").recipeInfo(new RecipeInfo()).recipeStatistics(new RecipeStatistics())
                 .steps(new ArrayList<>()).tags(new ArrayList<>()).ingredients(new ArrayList<>())
                 .build();
-        recipeService.createRecipe(recipe,new ArrayList<>(),author.getEmail());
-
+        recipeService.createRecipe(recipe, new ArrayList<>(), author.getEmail());
+        // @TransactionalEventListener의 AFTER_COMMIT을 위한 end 처리
         TestTransaction.flagForCommit();
         TestTransaction.end();
+        TestTransaction.start();
 
-        // then : sender가 author, receiver가 follower인 NEW_RECIPE 알림이 1개
-        //        sender가 follower, receiver가 author인 FOLLOW 알림이 1개 생성된다.
-        await().atMost(2, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    assertAll(
-                            () -> assertEquals(
-                                    1, notificationRepository.findByReceiver(follower).size()),
-                            () -> assertEquals(
-                                    1, notificationRepository.findByReceiver(author).size()));
-                });
+        // then : sender가 author인 알림이 발송된다.
+        ArgumentCaptor<NotificationMessage> argumentCaptor =
+                ArgumentCaptor.forClass(NotificationMessage.class);
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            // Awaitility를 이용한 비동기 테스트
+            verify(notificationMessageSender)
+                    .sendNotificationMessage(argumentCaptor.capture());
+        });
+        NotificationMessage sent = argumentCaptor.getValue();
+        assertEquals(NotificationType.NEW_RECIPE, sent.getNotificationType());
+        assertEquals(author.getId(), sent.getSenderId());
+    }
 
-        Notification createRecipenotification = notificationRepository.findByReceiver(follower).get(0);
-        assertEquals(author.getId(),createRecipenotification.getSender().getId()); // sender
-        assertEquals(NotificationType.NEW_RECIPE, createRecipenotification.getNotificationType()); // NEW_RECIPE
+    @Test
+    @Transactional
+    @DisplayName("특정 유저를 팔로우하면 팔로우 알림 생성 메세지가 발송된다.")
+    public void followNotificationTest() {
+        // given : 팔로우 당하는 followed, 팔로우하는 following 유저가 존재한다.
+        User followed = userRepository.save(User.builder()
+                .name("followed").email("followed@test.com").role(Role.USER).build());
+        User following = userRepository.save(User.builder()
+                .name("following").email("following@test.com").role(Role.USER).build());
 
-        Notification followNotification = notificationRepository.findByReceiver(author).get(0);
-        assertEquals(follower.getId(), followNotification.getSender().getId());
-        assertEquals(NotificationType.FOLLOW, followNotification.getNotificationType());
+        // when : following 유저가 followed 유저를 팔로우한다.
+        followService.follow(following.getEmail(),followed.getId());
+        // @TransactionalEventListener의 AFTER_COMMIT을 위한 end 처리
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        // then : sender가 following, receiver가 follower인 follow 알림이 발송된다.
+        ArgumentCaptor<NotificationMessage> argumentCaptor =
+                ArgumentCaptor.forClass(NotificationMessage.class);
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            // Awaitility를 이용한 비동기 테스트
+            verify(notificationMessageSender)
+                    .sendNotificationMessage(argumentCaptor.capture());
+        });
+        NotificationMessage sent = argumentCaptor.getValue();
+        assertEquals(NotificationType.FOLLOW, sent.getNotificationType());
+        assertEquals(followed.getId(), sent.getReceiverId());
+        assertEquals(following.getId(), sent.getSenderId());
     }
 }

--- a/src/test/java/com/recipetory/notification/application/TestNotificationRepository.java
+++ b/src/test/java/com/recipetory/notification/application/TestNotificationRepository.java
@@ -1,0 +1,49 @@
+package com.recipetory.notification.application;
+
+import com.recipetory.notification.domain.Notification;
+import com.recipetory.notification.domain.NotificationRepository;
+import com.recipetory.user.domain.User;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TestNotificationRepository implements NotificationRepository {
+    private final List<Notification> notifications = new ArrayList<>();
+    private final AtomicLong atomicLong = new AtomicLong(1L);
+
+    @Override
+    public Notification save(Notification notification) {
+        Notification created = Notification.builder()
+                .id(atomicLong.getAndIncrement())
+                .notificationType(notification.getNotificationType())
+                .message(notification.getMessage())
+                .sender(notification.getSender()).receiver(notification.getReceiver())
+                .path(notification.getPath()).build();
+        notifications.add(created);
+        return created;
+    }
+
+    @Override
+    public Optional<Notification> findById(Long id) {
+        return notifications.stream().filter(notification ->
+                notification.getId().equals(id)).findAny();
+    }
+
+    @Override
+    public List<Notification> findByReceiver(User receiver) {
+        return notifications.stream().filter(notification ->
+                notification.getReceiver().getId().equals(receiver.getId())).toList();
+    }
+
+    @Override
+    public void deleteById(Long notificationId) {
+        findById(notificationId).ifPresent(notifications::remove);
+    }
+
+    @Override
+    public void deleteAllByReceiver(User receiver) {
+        findByReceiver(receiver).forEach(notifications::remove);
+    }
+}

--- a/src/test/java/com/recipetory/notification/infrastructure/NotificationListenerTest.java
+++ b/src/test/java/com/recipetory/notification/infrastructure/NotificationListenerTest.java
@@ -1,0 +1,55 @@
+package com.recipetory.notification.infrastructure;
+
+import com.recipetory.notification.application.TestNotificationRepository;
+import com.recipetory.notification.domain.Notification;
+import com.recipetory.notification.domain.NotificationRepository;
+import com.recipetory.notification.domain.NotificationType;
+import com.recipetory.notification.presentation.dto.NotificationMessage;
+import com.recipetory.user.domain.Role;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.UserRepository;
+import com.recipetory.user.domain.follow.FollowRepository;
+import com.recipetory.user.service.TestFollowRepository;
+import com.recipetory.user.service.TestUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NotificationListenerTest {
+    private KafkaNotificationListener notificationListener;
+    NotificationRepository notificationRepository = new TestNotificationRepository();
+    UserRepository userRepository = new TestUserRepository();
+    FollowRepository followRepository = new TestFollowRepository();
+
+    @BeforeEach
+    public void setUp() {
+        notificationListener = new KafkaNotificationListener(
+                notificationRepository, userRepository, followRepository);
+    }
+
+    @Test
+    @DisplayName("도착한 알림 메세지에 맞게 알림을 저장한다.")
+    public void notificationListenerTest() {
+        // given : sender, receiver 유저가 설정된 NotificationMessage가 발행된다.
+        User sender = userRepository.save(
+                User.builder().name("sender").email("sender@email.com").role(Role.USER).build());
+        User receiver = userRepository.save(
+                User.builder().name("receiver").email("receiver@email.com").role(Role.USER).build());
+        NotificationMessage message = NotificationMessage.builder()
+                .senderId(sender.getId()).receiverId(receiver.getId())
+                .notificationType(NotificationType.FOLLOW).build();
+
+        // when :
+        notificationListener.saveNotification(message);
+
+        // then : 메세지로 전송된 것과 같은 알림 entity가 저장되었다.
+        List<Notification> found = notificationRepository.findByReceiver(receiver);
+        assertAll(() -> assertEquals(1,found.size()),
+                () -> assertEquals(sender.getId(), found.get(0).getSender().getId()),
+                () -> assertEquals(message.getNotificationType(), found.get(0).getNotificationType()));
+    }
+}

--- a/src/test/java/com/recipetory/recipe/application/TestRecipeRepository.java
+++ b/src/test/java/com/recipetory/recipe/application/TestRecipeRepository.java
@@ -1,7 +1,11 @@
 package com.recipetory.recipe.application;
 
-import com.recipetory.recipe.domain.Recipe;
-import com.recipetory.recipe.domain.RecipeRepository;
+import com.recipetory.recipe.domain.*;
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import com.recipetory.tag.domain.Tag;
+import com.recipetory.tag.domain.TagName;
+import com.recipetory.user.domain.User;
+import com.recipetory.utils.exception.EntityNotFoundException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,13 +15,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class TestRecipeRepository implements RecipeRepository {
     private final List<Recipe> recipes = new ArrayList<>();
     private final AtomicLong atomicLong = new AtomicLong(1L);
-
-    @Override
-    public Optional<Recipe> findByTitle(String title) {
-        return recipes.stream()
-                .filter(recipe -> recipe.getTitle().equals(title))
-                .findAny();
-    }
 
     @Override
     public Recipe save(Recipe recipe) {
@@ -44,14 +41,41 @@ public class TestRecipeRepository implements RecipeRepository {
     }
 
     @Override
-    public List<Recipe> findByTitleContains(String title) {
-        return recipes.stream()
-                .filter(recipe -> recipe.getTitle().contains(title))
+    public RecipeDocument getDocumentById(Long id) {
+        return RecipeDocument.fromEntity(findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Recipe", String.valueOf(id))));
+    }
+
+    @Override
+    public List<RecipeDocument> findByRecipeInfo(String title, CookingTime cookingTime, Difficulty difficulty, Serving serving) {
+        return recipes.stream().filter(recipe -> {
+            RecipeInfo recipeInfo = recipe.getRecipeInfo();
+            return recipe.getTitle().contains(title)
+                    && (cookingTime.equals(CookingTime.UNDEFINED) || recipeInfo.getCookingTime().equals(cookingTime))
+                    && (difficulty.equals(Difficulty.UNDEFINED) || recipeInfo.getDifficulty().equals(difficulty))
+                    && (serving.equals(Serving.UNDEFINED) || recipeInfo.getServing().equals(serving));
+        }).map(RecipeDocument::fromEntity).toList();
+    }
+
+    @Override
+    public List<RecipeDocument> findByAuthor(User author) {
+        return recipes.stream().filter(
+                recipe -> recipe.getAuthor().equals(author))
+                .map(RecipeDocument::fromEntity)
                 .toList();
     }
 
     @Override
+    public List<RecipeDocument> findByTagNames(List<TagName> tagNames) {
+        return recipes.stream().filter(recipe ->
+            recipe.getTags().stream().map(Tag::getTagName)
+                    .toList().containsAll(tagNames))
+                .map(RecipeDocument::fromEntity).toList();
+    }
+
+    @Override
     public void deleteById(Long id) {
-        findById(id).ifPresent(recipes::remove);
+        recipes.stream().filter(recipe -> recipe.getId() == id)
+                .findAny().ifPresent(recipes::remove);
     }
 }

--- a/src/test/java/com/recipetory/recipe/infrastructure/RecipeDocumentTest.java
+++ b/src/test/java/com/recipetory/recipe/infrastructure/RecipeDocumentTest.java
@@ -1,0 +1,120 @@
+package com.recipetory.recipe.infrastructure;
+
+import com.recipetory.recipe.application.RecipeService;
+import com.recipetory.recipe.domain.Recipe;
+import com.recipetory.recipe.domain.RecipeInfo;
+import com.recipetory.recipe.domain.RecipeStatistics;
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import com.recipetory.user.domain.Role;
+import com.recipetory.user.domain.User;
+import com.recipetory.user.domain.UserRepository;
+import com.recipetory.user.infrastructure.UserJpaRepository;
+import com.recipetory.utils.es.KafkaDocumentMessageSender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+public class RecipeDocumentTest {
+    @MockBean
+    private KafkaDocumentMessageSender documentMessageSender;
+    @Autowired
+    private RecipeService recipeService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private RecipeJpaRepository recipeJpaRepository;
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @BeforeEach
+    public void setUp() {
+        recipeJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("recipe 엔티티를 생성하면 document 생성 메세지가 발송된다.")
+    public void createRecipeDocumentTest() {
+        // given, when : test 유저와 test 레시피를 저장한다.
+        User author = userRepository
+                .save(User.builder()
+                        .name("test").role(Role.USER).email("test@test.com")
+                        .build());
+        Recipe recipe = Recipe.builder()
+                .title("test").tags(new ArrayList<>())
+                .recipeStatistics(new RecipeStatistics()).recipeInfo(new RecipeInfo())
+                .steps(new ArrayList<>())
+                .build();
+        recipeService.createRecipe(recipe, new ArrayList<>(), author.getEmail());
+        // @TransactionalEventListener의 AFTER_COMMIT을 위한 end 처리
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        // then : save된 entity와 같은 id의 document 저장 메세지가 발송된다.
+        ArgumentCaptor<RecipeDocument> argumentCaptor =
+                ArgumentCaptor.forClass(RecipeDocument.class);
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            // Awaitility를 이용한 비동기 테스트
+            verify(documentMessageSender).sendRecipeDocument(argumentCaptor.capture());
+        });
+
+        RecipeDocument sent = argumentCaptor.getValue();
+        assertEquals(recipe.getId(), sent.getId());
+        assertAll(() -> assertEquals(recipe.getAuthor().getId(),sent.getAuthorId()),
+                () -> assertEquals(recipe.getTitle(),sent.getTitle()));
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("recipe 엔티티를 삭제하면 document 생성 메세지가 발송된다.")
+    public void deleteRecipeDocumentTest() {
+        // given : test 유저와 test 레시피를 저장한다.
+        User author = userRepository
+                .save(User.builder()
+                        .name("test").role(Role.USER).email("test@test.com")
+                        .build());
+        Recipe recipe = Recipe.builder()
+                .title("test").tags(new ArrayList<>())
+                .recipeStatistics(new RecipeStatistics()).recipeInfo(new RecipeInfo())
+                .steps(new ArrayList<>())
+                .build();
+        recipeService.createRecipe(recipe, new ArrayList<>(), author.getEmail());
+
+        // when : 저장된 recipe entity를 삭제한다.
+        recipeService.deleteRecipeById(recipe.getId(),author.getEmail());
+        // @TransactionalEventListener의 AFTER_COMMIT을 위한 end 처리
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        // then : delete된 entity와 같은 id의 document 삭제 메세지가 발송된다.
+        ArgumentCaptor<Long> argumentCaptor =
+                ArgumentCaptor.forClass(Long.class);
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            // Awaitility를 이용한 비동기 테스트
+            verify(documentMessageSender).sendDeleteRecipeDocument(argumentCaptor.capture());
+        });
+
+        Long sent = argumentCaptor.getValue();
+        assertEquals(recipe.getId(), sent);
+    }
+}

--- a/src/test/java/com/recipetory/recipe/infrastructure/RecipeEsTest.java
+++ b/src/test/java/com/recipetory/recipe/infrastructure/RecipeEsTest.java
@@ -1,0 +1,111 @@
+package com.recipetory.recipe.infrastructure;
+
+import com.recipetory.recipe.domain.*;
+import com.recipetory.recipe.domain.document.RecipeDocument;
+import com.recipetory.tag.domain.TagName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class RecipeEsTest {
+    @Autowired
+    private RecipeDocumentRepository recipeDocumentRepository;
+    @Autowired
+    private RecipeDocumentQueryService recipeDocumentQueryService;
+
+    @AfterEach
+    public void setUp() {
+        recipeDocumentRepository.deleteAll();
+    }
+    @Test
+    @DisplayName("tag가 모두 들어있는 레시피를 검색한다.")
+    public void tagsSearchTest() {
+        // given : recipe1은 BOIL, DIET, BREAD 태그를
+        //         recipe2는 BOIL, DIET 태그를 갖는다.
+        RecipeDocument recipe1 = RecipeDocument.builder().title("검색되어야하는 레시피")
+                .recipeStatistics(new RecipeStatistics())
+                .id(1L)
+                .authorId(1L).createdAt(LocalDateTime.now())
+                .tags(Arrays.asList(TagName.BOIL,TagName.DIET,TagName.BREAD))
+                .recipeInfo(new RecipeInfo())
+                .build();
+        RecipeDocument recipe2 = RecipeDocument.builder().title("검색되면 안되는 레시피")
+                .recipeStatistics(new RecipeStatistics())
+                .id(2L)
+                .authorId(1L).createdAt(LocalDateTime.now())
+                .tags(Arrays.asList(TagName.BOIL,TagName.DIET))
+                .recipeInfo(new RecipeInfo())
+                .build();
+        recipeDocumentRepository.saveAll(Arrays.asList(recipe1, recipe2));
+
+        // when : BOIL, DIET, BREAD 태그로 findByTagNames()를 호출하여 레시피를 조회한다.
+        List<RecipeDocument> found = recipeDocumentQueryService
+                .findByTagNames(Arrays.asList(TagName.BOIL,TagName.DIET,TagName.BREAD));
+        List<Long> foundIds = found.stream().map(RecipeDocument::getId).toList();
+
+        // then : 3개의 태그를 모두 갖는 recipe1만이 조회 결과에 포함된다.
+        assertAll(
+                () -> assertTrue(foundIds.contains(recipe1.getId())),
+                () -> assertFalse(foundIds.contains(recipe2.getId())));
+    }
+
+    @Test
+    @DisplayName("recipeInfo 검색 조건으로 검색이 가능하다.")
+    public void recipeInfoSearchTest() {
+        // given : 특정 title, recipeInfo값을 갖는 레시피가 존재한다.
+        RecipeInfo recipeInfo = RecipeInfo.builder()
+                .cookingTime(CookingTime.LESS_THAN_20)
+                .difficulty(Difficulty.HARD)
+                .serving(Serving.ONE).build();
+        RecipeDocument recipe = RecipeDocument.builder().id(1L)
+                .title("검색되어야하는 레시피").recipeInfo(recipeInfo).build();
+        recipeDocumentRepository.save(recipe);
+
+        // when : 저장된 레시피의 title, recipeInfo를 조건으로 findByRecipeInfo()를 호출하여
+        //        레시피를 조회한다.
+        List<RecipeDocument> found = recipeDocumentQueryService.findByRecipeInfo(
+                "레시피",
+                recipeInfo.getCookingTime(),
+                recipeInfo.getDifficulty(),
+                recipeInfo.getServing());
+        List<Long> foundIds = found.stream().map(RecipeDocument::getId).toList();
+
+        // then : 조회 결과에 해당 레시피가 포함된다.
+        assertTrue(foundIds.contains(recipe.getId()));
+    }
+
+    @Test
+    @DisplayName("recipeInfo에 UNDEFINED 항목은 검색 조건에서 제외된다.")
+    public void recipeInfoUndefinedTest() {
+        // given : recipeInfo 값이 다른 recipe1, recipe2가 존재한다.
+        RecipeDocument recipe1 = RecipeDocument.builder().id(1L)
+                .title("test1")
+                .recipeInfo(RecipeInfo.builder()
+                        .cookingTime(CookingTime.LESS_THAN_20).difficulty(Difficulty.HARD).serving(Serving.ONE)
+                        .build()).build();
+        RecipeDocument recipe2 = RecipeDocument.builder().id(2L)
+                .title("test2")
+                .recipeInfo(RecipeInfo.builder()
+                        .cookingTime(CookingTime.LESS_THAN_10).difficulty(Difficulty.EASY).serving(Serving.FOUR)
+                        .build()).build();
+        recipeDocumentRepository.saveAll(Arrays.asList(recipe1, recipe2));
+
+        // when : 검색 조건의 recipeInfo 항목을 UNDEFINED로 설정한 뒤 검색한다.
+        List<RecipeDocument> found = recipeDocumentQueryService
+                .findByRecipeInfo("", CookingTime.UNDEFINED, Difficulty.UNDEFINED, Serving.UNDEFINED);
+        List<Long> foundIds = found.stream().map(RecipeDocument::getId).toList();
+
+        // then : recipe1, recipe2가 모두 검색된다.
+        assertTrue(foundIds.containsAll(Arrays.asList(recipe1.getId(), recipe2.getId())));
+    }
+}

--- a/src/test/java/com/recipetory/recipe/infrastructure/RecipeSearchTest.java
+++ b/src/test/java/com/recipetory/recipe/infrastructure/RecipeSearchTest.java
@@ -4,10 +4,10 @@ import com.recipetory.recipe.domain.*;
 import com.recipetory.recipe.domain.document.RecipeDocument;
 import com.recipetory.tag.domain.TagName;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
@@ -17,7 +17,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-public class RecipeEsTest {
+@AutoConfigureTestDatabase
+public class RecipeSearchTest {
     @Autowired
     private RecipeDocumentRepository recipeDocumentRepository;
     @Autowired
@@ -28,7 +29,7 @@ public class RecipeEsTest {
         recipeDocumentRepository.deleteAll();
     }
     @Test
-    @DisplayName("tag가 모두 들어있는 레시피를 검색한다.")
+    @DisplayName("검색하려는 tag가 모두 들어있는 레시피를 검색한다.")
     public void tagsSearchTest() {
         // given : recipe1은 BOIL, DIET, BREAD 태그를
         //         recipe2는 BOIL, DIET 태그를 갖는다.

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  data:
+    elasticsearch:
+      hosts: localhost
+      port: 9200
   kafka:
     bootstrap-servers: localhost:9092
     group-id: recipetory-test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,7 +4,7 @@ spring:
       hosts: localhost
       port: 9200
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:9093
     group-id: recipetory-test
     consumer:
       auto-offset-reset: earliest


### PR DESCRIPTION
## 개요
멘토링 시간에 말씀드렸던 일들을 진행했습니닷. 현재 RecipeDocument라는 네이밍(?)으로 index에 저장될 document 객체를 만들었고, 조회가 필요할 때 한꺼번에 불러와져야할 tag, ingredient, step을 nested field로 두었어요..
1. 특정 tagName이 전부 포함된 레시피를 검색할 수 있고
2. 제목, 걸리는 시간, 난이도, serving(인분?) 각각의 조건에 따라 검색할 수 있는
endpoint를 추가했어요!!!!!

## 작업사항
- 이거 했습니다 🥲 근데 일단 Recipe만 index로 존재하는 상태라 토픽이 하나인데, 인덱스로 저장할 엔티티 종류가 많아지면 토픽도 늘려야할까요?
<img width="900" alt="image" src="https://github.com/f-lab-edu/recipetory/assets/69233405/a9989dd7-b2a8-4f76-9816-0295e4632229">

- 생각보다 변경 파일이 많은데, 조회 전용 객체를 Recipe -> RecipeDocument로 바꾸면서 기존에 Recipe 자체를 이용하던 서비스 역시 코드가 수정되었기 때문입니당!
- `RecipeSearchController`, `RecipeSearchService`를 분리했고,,
- `ElasticSearchClient`를 이용한 쿼리는 `RecipeDocumentQueryService`라는 놈에 있습니다 (얘에 능숙해지느라 좀.. 시간이 걸림.. ㅈㅅㅈㅅㅈㅅ)

## ??
- es는 transactional이 적용 안되므로.. entity update가 있는 곳에 역시 save()를 해줘야하는거겠죠? create 할 때와 같은 과정을 거치면 되는걸까요..
