### PR TITLE
es 쿼리 로직 수정

### DIFF
--- a/src/main/java/com/recipetory/recipe/infrastructure/RecipeDocumentQueryService.java
+++ b/src/main/java/com/recipetory/recipe/infrastructure/RecipeDocumentQueryService.java
@@ -1,16 +1,14 @@
 package com.recipetory.recipe.infrastructure;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
-import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.recipetory.recipe.domain.CookingTime;
 import com.recipetory.recipe.domain.Difficulty;
-import com.recipetory.recipe.domain.document.RecipeDocument;
 import com.recipetory.recipe.domain.Serving;
+import com.recipetory.recipe.domain.document.RecipeDocument;
 import com.recipetory.tag.domain.TagName;
 import com.recipetory.utils.exception.EsClientException;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RecipeDocumentQueryService {
     private final ElasticsearchClient esClient;
+    private final RecipeQueryHelper recipeQueryHelper;
 
     /**
      * 인자로 주어진 tagName List의 tag가 "전부" 포함된 RecipeDocument를 반환한다.
@@ -63,32 +62,13 @@ public class RecipeDocumentQueryService {
     ) {
         // title이 빈칸이거나, recipeInfo 항목 타입이 UNDEFIEND이면 검색 조건에서 제외
         List<Query> infoQueries = new ArrayList<>();
-        if (title != "") {
-            infoQueries.add(MatchQuery.of(q ->
-                    q.field("title").query(title))._toQuery());
-        }
-        if (cookingTime != CookingTime.UNDEFINED) {
-            System.out.println("undefined가 아니빈다!");
-            infoQueries.add(NestedQuery.of(
-                    n -> n.path("recipeInfo").query(
-                            q -> q.match(
-                                    s -> s.field("recipeInfo.cookingTime")
-                                            .query(cookingTime.name()))))._toQuery());
-        }
-        if (difficulty != Difficulty.UNDEFINED) {
-            infoQueries.add(NestedQuery.of(n ->
-                    n.path("recipeInfo").query(
-                            q -> q.match(
-                                    s -> s.field("recipeInfo.difficulty")
-                                            .query(difficulty.name()))))._toQuery());
-        }
-        if (serving != Serving.UNDEFINED) {
-            infoQueries.add(NestedQuery.of(n ->
-                    n.path("recipeInfo").query(
-                            q -> q.match(
-                                    s -> s.field("recipeInfo.serving")
-                                            .query(serving.name()))))._toQuery());
-        }
+        infoQueries.add(recipeQueryHelper.buildTitleQuery(title));
+        infoQueries.add(recipeQueryHelper.buildRecipeInfoQuery(
+                "recipeInfo.cookingTime", cookingTime.name()));
+        infoQueries.add(recipeQueryHelper.buildRecipeInfoQuery(
+                "recipeInfo.difficulty", difficulty.name()));
+        infoQueries.add(recipeQueryHelper.buildRecipeInfoQuery(
+                "recipeInfo.serving", serving.name()));
 
         try {
             SearchResponse<RecipeDocument> response = esClient.search(

--- a/src/main/java/com/recipetory/recipe/infrastructure/RecipeQueryHelper.java
+++ b/src/main/java/com/recipetory/recipe/infrastructure/RecipeQueryHelper.java
@@ -1,0 +1,43 @@
+package com.recipetory.recipe.infrastructure;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RecipeQueryHelper {
+    /**
+     * title 문자열에 대한 match query를 반환한다.
+     * 인자로 주어진 title이 빈 문자열일 경우 조건에 포함하지 않는다.
+     * @param title
+     * @return
+     */
+    public Query buildTitleQuery(String title) {
+        BoolQuery.Builder boolQuery = QueryBuilders.bool();
+        if (title != "") {
+            return boolQuery.must(MatchQuery.of(q ->
+                    q.field("title").query(title))._toQuery()).build()._toQuery();
+        } else {
+            return boolQuery.build()._toQuery();
+        }
+    }
+
+    /**
+     * RecipeInfo 항목에 대한 match query를 반환한다.
+     * 검색하고자 하는 nested fieldName과 enum name을 인자로 받는다.
+     * 인자로 들어온 enum value name이 UNDEFINED일 경우 조건에 포함하지 않는다.
+     * @param fieldName nested field name
+     * @param name enum value name
+     * @return
+     */
+    public Query buildRecipeInfoQuery(String fieldName, String name) {
+        BoolQuery.Builder boolQuery = QueryBuilders.bool();
+        if (name != "UNDEFINED") {
+            NestedQuery.Builder nestedQuery =
+                    QueryBuilders.nested().path("recipeInfo").query(
+                            q -> q.match(
+                                    s -> s.field(fieldName).query(name)));
+            boolQuery.must(b -> b.nested(nestedQuery.build()));
+        }
+        return boolQuery.build()._toQuery();
+    }
+}


### PR DESCRIPTION
## 개요
- [저번 PR](https://github.com/f-lab-edu/recipetory/pull/31#pullrequestreview-1608239762)때 말씀하신 내용을 나름 뭐 어떻게 해보았습니다.

## 변경로직
- 기존엔 조회 메소드 인자로 들어온 내용 각각에 대해 `"UNDEFINED"`의 여부를 하나하나 확인하고 그렇지 않을 경우에 Query를 추가하는 형식이었는데요, `RecipeQueryHelper`라는 컴포넌트를 따로 만들어 해당 로직을 다른 곳에서 처리하도록 해보았어요.