### PR TITLE
엔진엑스 웹서버 구축 + redis 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'

--- a/src/main/java/com/recipetory/RecipetoryApplication.java
+++ b/src/main/java/com/recipetory/RecipetoryApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 @SpringBootApplication
 @EnableAsync
 @EnableCaching
+@EnableRedisHttpSession
 public class RecipetoryApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/recipetory/RecipetoryApplication.java
+++ b/src/main/java/com/recipetory/RecipetoryApplication.java
@@ -2,10 +2,12 @@ package com.recipetory;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableAsync
+@EnableCaching
 public class RecipetoryApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/recipetory/config/auth/dto/SessionUser.java
+++ b/src/main/java/com/recipetory/config/auth/dto/SessionUser.java
@@ -4,9 +4,11 @@ import com.recipetory.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.io.Serializable;
+
 @Getter
 @Builder
-public class SessionUser {
+public class SessionUser implements Serializable {
     private String name;
     private String email;
     private Long id;

--- a/src/main/java/com/recipetory/config/redis/CacheConfiguration.java
+++ b/src/main/java/com/recipetory/config/redis/CacheConfiguration.java
@@ -1,0 +1,36 @@
+package com.recipetory.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@RequiredArgsConstructor
+public class CacheConfiguration {
+    private final RedisConnectionFactory redisConnectionFactory;
+    private static final long CACHE_TTL = 2L;
+
+    @Bean
+    public CacheManager redisCacheManager() {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext
+                        .fromSerializer(new StringRedisSerializer()).getKeySerializationPair())
+                .serializeValuesWith(RedisSerializationContext
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()).getValueSerializationPair())
+                .entryTtl(Duration.ofHours(CACHE_TTL));
+
+        RedisCacheManager cacheManager = RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration).build();
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/recipetory/config/redis/RedisConfiguration.java
+++ b/src/main/java/com/recipetory/config/redis/RedisConfiguration.java
@@ -1,0 +1,42 @@
+package com.recipetory.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * redis 서버와의 connection을 위해 connection factory를 설정하고
+ * 해당 connection을 이용하는 template bean을 생성
+ */
+@Configuration
+public class RedisConfiguration {
+    @Value("${spring.redis.port}")
+    public int port;
+
+    @Value("${spring.redis.host}")
+    public String host;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setHostName(host);
+        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
+        return connectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String,Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String,Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setConnectionFactory(connectionFactory);
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/recipetory/config/redis/RedisConfiguration.java
+++ b/src/main/java/com/recipetory/config/redis/RedisConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -17,10 +18,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfiguration {
     @Value("${spring.redis.port}")
-    public int port;
+    private int port;
 
     @Value("${spring.redis.host}")
-    public String host;
+    private String host;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {

--- a/src/main/java/com/recipetory/recipe/application/RecipeService.java
+++ b/src/main/java/com/recipetory/recipe/application/RecipeService.java
@@ -17,6 +17,7 @@ import com.recipetory.user.domain.exception.NotOwnerException;
 import com.recipetory.utils.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -121,6 +122,7 @@ public class RecipeService {
      * index에 제공할 추천 레시피를 반환한다.
      * @return featured(추천) recipe
      */
+    @Cacheable(value = "getFeaturedRecipes", cacheManager = "redisCacheManager")
     @Transactional(readOnly = true)
     public RecipeListDto getFeaturedRecipes() {
         List<RecipeDocument> featured = recipeRepository.getFeatured();

--- a/src/main/java/com/recipetory/recipe/application/RecipeService.java
+++ b/src/main/java/com/recipetory/recipe/application/RecipeService.java
@@ -17,6 +17,7 @@ import com.recipetory.user.domain.exception.NotOwnerException;
 import com.recipetory.utils.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -94,6 +95,8 @@ public class RecipeService {
      * @param recipeId
      */
     @Transactional
+    // cache에 저장된 데이터라면 cache update
+    @CacheEvict(value = "getFeaturedRecipes", cacheManager = "redisCacheManager")
     public void deleteRecipeById(Long recipeId, String logInEmail) {
         // 레시피 작성자만 삭제 가능
         Recipe found = recipeRepository.findById(recipeId)

--- a/src/main/java/com/recipetory/recipe/domain/RecipeStatistics.java
+++ b/src/main/java/com/recipetory/recipe/domain/RecipeStatistics.java
@@ -1,5 +1,6 @@
 package com.recipetory.recipe.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;
@@ -48,9 +49,5 @@ public class RecipeStatistics {
     }
     public void subtractBookMarkCount() {
         this.bookMarkCount -= 1;
-    }
-
-    public String getRatingFormat() {
-        return String.format("%.1f",ratings / 10.0);
     }
 }

--- a/src/main/java/com/recipetory/recipe/domain/RecipeStatistics.java
+++ b/src/main/java/com/recipetory/recipe/domain/RecipeStatistics.java
@@ -1,6 +1,5 @@
 package com.recipetory.recipe.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,6 +16,8 @@ spring:
   redis:
     host: localhost
     port: 6379
+  session:
+    store-type: redis
   jpa:
     properties:
       hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,9 @@ spring:
     elasticsearch:
       hosts: localhost
       port: 9200
+  redis:
+    host: localhost
+    port: 6379
   jpa:
     properties:
       hibernate:

--- a/src/main/resources/application-server.yml
+++ b/src/main/resources/application-server.yml
@@ -13,12 +13,15 @@ spring:
     elasticsearch:
       hosts: 10.178.0.10,10.178.0.11
       port: 9200
+  redis:
+    host: 10.146.0.2
+    port: 6379
   jpa:
     properties:
       hibernate:
         default_batch_fetch_size: 1000
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   security:
     oauth2:
       client:

--- a/src/main/resources/application-server.yml
+++ b/src/main/resources/application-server.yml
@@ -16,6 +16,8 @@ spring:
   redis:
     host: 10.146.0.2
     port: 6379
+  session:
+    store-type: redis
   jpa:
     properties:
       hibernate:
@@ -36,13 +38,13 @@ spring:
             client-name: naver
             client-id: xCOoChU6Z_Y0mqFWAigP
             client-secret: wTKSqsL3gH
-            redirect-uri: http://34.64.192.158/login/oauth2/code/naver
+            redirect-uri: http://34.84.6.143/login/oauth2/code/naver
             authorization-grant-type: authorization_code
             scope: email,nickname
           kakao:
             client-name: kakao
             client-id: 440b9d834501c4337ae0d9c753156417
-            redirect-uri: http://34.64.192.158/login/oauth2/code/kakao
+            redirect-uri: http://34.84.6.143/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             scope: account_email,profile_nickname
         provider:

--- a/src/main/resources/static/recipe-new.html
+++ b/src/main/resources/static/recipe-new.html
@@ -375,7 +375,8 @@
               window.location.href = "/view/login";
             } else {
               console.log("error! : ", error);
-              alert(error);
+              alert("알 수 없는 오류가 발생했습니다!");
+              window.location.href = "/view/recipes/new";
             }
           });
       });


### PR DESCRIPTION
## 개요
직전 멘토링 시간에 말씀드린 이거 구성했습니다. 캐시를 사용했고, 어플리케이션 서버와 로드밸런서를 추가했고, 글로벌 세션을 이용했어요.
<img width="754" alt="image" src="https://github.com/f-lab-edu/recipetory/assets/69233405/57a2620a-7a1a-4213-8836-ad270e55dcbb">
코드 변화는
1. redis configuration
2. index 페이지에서 호출되는 메소드에 `@Cacheable` 붙인 것
3. 세션에 저장될 `SessionUser`를 redis 서버에 저장하기 위해 Serializable을 붙인 것..
정도겠네요.

도입 자체보다 인프라 구축하고 테스트한게 더 커서 ..ㅎㅎ 추가된 코드는 많이 없네욥. 같은 region 부하테스트는 내일모레중으로 해보도록 할게요.

## ^-^
- 지금 사용한 레디스나 엔진엑스 관련해서, 뭔가 꼭 알아야한다거나? 이걸 사용했다고 프로젝트에 적어온 저같은 사람에게 물어보고 싶은 점이라던가? 있다면 남겨주면 감사드립니다.
